### PR TITLE
imgcolor: отделяне на преливките в CMYK акумулатор (v0.4)

### DIFF
--- a/docs/superpowers/plans/2026-07-13-imgcolor-cmyk-separation.md
+++ b/docs/superpowers/plans/2026-07-13-imgcolor-cmyk-separation.md
@@ -1,0 +1,931 @@
+# imgcolor CMYK Separation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Separate gradient/transition pixels from solid colors in `imgcolor` analysis: solids keep the existing cluster list, transitions produce a normalized CMYK ink-composition accumulator.
+
+**Architecture:** New wrapper-side classes (no edits under `imgcolor/lib/`): a three-way spatial classifier (coherent-drift + erosion + edge-capped reconstruction, per spec §4), a mask-aware `Raster` decorator feeding the *unchanged* library clustering, a two-engine RGB→CMYK converter (Imagick ICC / math fallback), and an accumulator producing `cmykJson`. Orchestrated by `imgcolor_Separation::process()` (bgERP-free, CLI-testable) and `imgcolor_Analyzer::processSeparated()` (bgERP glue). Spec: `docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.md`.
+
+**Tech Stack:** PHP (bgERP legacy style: no `strict_types`, docblock types, `array()` literals), GD, vendored `ImageColorAnalyzer` library contracts, optional ext-imagick.
+
+## Global Constraints
+
+- Never edit files under `imgcolor/lib/` (docs/integration.md).
+- New wrapper classes must not use bgERP APIs (`core_*`, `imgcolor_Setup`) except `imgcolor_Analyzer`, `imgcolor_Setup`, `imgcolor_Analyses`, `imgcolor_Demo` — the CLI tests run without a bgERP instance, mirroring `imgcolor/tests/cli_calibration.php`.
+- bgERP class files: `imgcolor/<Name>.class.php` defines `imgcolor_<Name>`; header docblocks in Bulgarian with `@category bgerp`, `@package imgcolor`, license GPL 3 — copy the style of `imgcolor/Calibration.class.php`.
+- Interface implementations of `\ImageColorAnalyzer\Contracts\Raster` must use typed signatures (the interface declares return types).
+- Classifier defaults (spec §4, calibrated): span=4, noiseDeltaE=1.0, coherenceMin=0.4, aaRadius=3, minSeed=20, edgeDeltaE=10.0, minCoverage=0.005, alphaThreshold=8.
+- Solid-only images must produce `colorsJson` byte-identical to the legacy path (proved by test, not asserted).
+- No ICC profile files are added to the repository.
+- All CLI tests must pass: `php imgcolor/tests/cli_setup_bucket.php && php imgcolor/tests/cli_calibration.php && php imgcolor/tests/cli_analysis_snapshot.php && php imgcolor/tests/cli_init_signature.php && php imgcolor/tests/cli_parity.php && php imgcolor/tests/cli_separation.php`
+- Commits: conventional style `feat(imgcolor): ...` / `test(imgcolor): ...`, no self-attribution.
+
+---
+
+### Task 1: `imgcolor_CmykConverter`
+
+**Files:**
+- Create: `imgcolor/CmykConverter.class.php`
+- Test: `imgcolor/tests/cli_separation.php` (new file, section 1)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: `new imgcolor_CmykConverter(array $cfg)` where `$cfg = array('engine' => 'auto'|'math'|'imagick', 'rgbProfile' => string, 'cmykProfile' => string)`; `convert(array $colors)` taking `list<array{0:int,1:int,2:int}>` returning `list<array{0:float,1:float,2:float,3:float}>` (fractions 0..1, same order); `getMetadata()` returning `array{engine:string, source_profile:string, destination_profile:?string, fallback:bool, version:int}`. Throws `InvalidArgumentException` on bad config.
+
+- [ ] **Step 1: Write the failing test skeleton + converter section**
+
+Create `imgcolor/tests/cli_separation.php`:
+
+```php
+<?php
+
+// Framework-free regression for the CMYK separation feature: classifier,
+// masked raster, CMYK converter/accumulator, and the bgERP-free orchestrator.
+// Requires PHP 8.2+ with GD; no bgERP instance needed (like cli_parity.php).
+// Usage: php imgcolor/tests/cli_separation.php
+
+$libBase = __DIR__ . '/../lib/image-color-analyzer/src/';
+
+spl_autoload_register(function ($class) use ($libBase) {
+    $prefix = 'ImageColorAnalyzer\\';
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return;
+    }
+
+    $rel = substr($class, strlen($prefix));
+    $file = $libBase . str_replace('\\', '/', $rel) . '.php';
+    if (is_file($file)) {
+        include_once $file;
+    }
+});
+
+require_once __DIR__ . '/../CmykConverter.class.php';
+
+function fail($msg)
+{
+    fwrite(STDERR, "FAIL: {$msg}\n");
+    exit(1);
+}
+
+function approx($a, $b, $tol, $what)
+{
+    if (abs($a - $b) > $tol) {
+        fail("{$what}: expected ~{$b}, got {$a}");
+    }
+}
+
+if (!extension_loaded('gd')) {
+    fail('ext-gd is not loaded in this CLI php');
+}
+
+// ---------------------------------------------------------------------------
+// 1) CMYK converter: math engine vectors, engine selection, metadata
+// ---------------------------------------------------------------------------
+
+$math = new imgcolor_CmykConverter(array('engine' => 'math', 'rgbProfile' => '', 'cmykProfile' => ''));
+
+$vectors = array(
+    // rgb                     => cmyk
+    array(array(255, 0, 0),   array(0.0, 1.0, 1.0, 0.0)),
+    array(array(0, 255, 0),   array(1.0, 0.0, 1.0, 0.0)),
+    array(array(0, 0, 255),   array(1.0, 1.0, 0.0, 0.0)),
+    array(array(0, 0, 0),     array(0.0, 0.0, 0.0, 1.0)),
+    array(array(255, 255, 255), array(0.0, 0.0, 0.0, 0.0)),
+    array(array(128, 128, 128), array(0.0, 0.0, 0.0, 1 - 128 / 255)),
+    array(array(255, 128, 0), array(0.0, 0.498, 1.0, 0.0)),
+);
+$in = array();
+foreach ($vectors as $v) {
+    $in[] = $v[0];
+}
+$out = $math->convert($in);
+if (count($out) !== count($in)) {
+    fail('converter must return one CMYK per input color');
+}
+foreach ($vectors as $i => $v) {
+    foreach (array('c', 'm', 'y', 'k') as $ch => $name) {
+        approx($out[$i][$ch], $v[1][$ch], 0.002, "math cmyk {$name} for rgb(" . implode(',', $v[0]) . ')');
+    }
+}
+if ($math->convert(array()) !== array()) {
+    fail('empty input must yield empty output');
+}
+
+$meta = $math->getMetadata();
+if ($meta['engine'] !== 'math' || $meta['fallback'] !== false || $meta['version'] !== 1
+    || $meta['source_profile'] !== 'assumed-sRGB' || $meta['destination_profile'] !== null) {
+    fail('math engine metadata mismatch: ' . json_encode($meta));
+}
+
+// auto without imagick/profiles degrades to math and records the fallback
+$auto = new imgcolor_CmykConverter(array('engine' => 'auto', 'rgbProfile' => '', 'cmykProfile' => ''));
+$meta = $auto->getMetadata();
+if ($meta['engine'] === 'math' && $meta['fallback'] !== true) {
+    fail('auto->math degradation must set fallback=true');
+}
+
+// invalid engine name rejected
+try {
+    new imgcolor_CmykConverter(array('engine' => 'lcms', 'rgbProfile' => '', 'cmykProfile' => ''));
+    fail('invalid engine must be rejected');
+} catch (InvalidArgumentException $e) {
+    if (strpos($e->getMessage(), 'engine') === false) {
+        fail('engine error message must name the field');
+    }
+}
+
+// explicit imagick engine without prerequisites is a loud error, not a fallback
+if (!extension_loaded('imagick')) {
+    try {
+        new imgcolor_CmykConverter(array('engine' => 'imagick', 'rgbProfile' => '', 'cmykProfile' => ''));
+        fail('engine=imagick without ext-imagick must be rejected');
+    } catch (InvalidArgumentException $e) {
+        // expected
+    }
+    echo "NOTE: ext-imagick absent - ICC conversion exercised only via metadata/fallback logic\n";
+}
+
+echo "PASS: cli_separation section 1 (converter)\n";
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `php imgcolor/tests/cli_separation.php`
+Expected: fatal error, `Failed opening required '.../CmykConverter.class.php'`
+
+- [ ] **Step 3: Implement the converter**
+
+Create `imgcolor/CmykConverter.class.php`:
+
+```php
+<?php
+
+
+/**
+ * RGB -> CMYK преобразувател за CMYK акумулатора на преливките.
+ *
+ * Два енджина: 'imagick-icc' (реална ICC конверсия през ext-imagick и
+ * конфигурирани профили) и 'math' (документирана апроксимативна формула,
+ * без цветови мениджмънт). 'auto' избира ICC когато е наличен, иначе math
+ * със записан fallback. Никакви ICC профили не се разпространяват с пакета -
+ * пътищата са конфигурация (IMGCOLOR_CMYK_ICC_*).
+ *
+ * Без bgERP зависимост - нарочно, за да е тестван директно с
+ * `php imgcolor/tests/cli_separation.php` (по образец на imgcolor_Calibration).
+ *
+ * @category  bgerp
+ * @package   imgcolor
+ *
+ * @license   GPL 3
+ * @since     v 0.4
+ */
+class imgcolor_CmykConverter
+{
+    /**
+     * Версия на алгоритъма за преобразуване - записва се в метаданните
+     * на резултата за възпроизводимост.
+     */
+    const VERSION = 1;
+
+
+    /**
+     * Реално избран енджин: 'math' или 'imagick-icc'
+     */
+    private $engine;
+
+
+    /**
+     * Дали 'auto' е деградирал до math (за одитируемост)
+     */
+    private $fallback = false;
+
+
+    /**
+     * Пътища до ICC профилите (при engine 'imagick-icc')
+     */
+    private $rgbProfilePath = '';
+    private $cmykProfilePath = '';
+
+
+    /**
+     * @param array $cfg array('engine' => 'auto'|'math'|'imagick',
+     *                         'rgbProfile' => string, 'cmykProfile' => string)
+     *
+     * @throws InvalidArgumentException при непознат енджин или engine=imagick
+     *                                  без налични предпоставки
+     */
+    public function __construct(array $cfg)
+    {
+        $engine = isset($cfg['engine']) ? (string) $cfg['engine'] : 'auto';
+        if (!in_array($engine, array('auto', 'math', 'imagick'), true)) {
+            throw new InvalidArgumentException("CMYK engine must be one of auto|math|imagick: {$engine}");
+        }
+
+        $rgb = isset($cfg['rgbProfile']) ? (string) $cfg['rgbProfile'] : '';
+        $cmyk = isset($cfg['cmykProfile']) ? (string) $cfg['cmykProfile'] : '';
+
+        $iccReady = extension_loaded('imagick')
+            && $rgb !== '' && is_readable($rgb)
+            && $cmyk !== '' && is_readable($cmyk);
+
+        if ($engine === 'imagick') {
+            if (!$iccReady) {
+                throw new InvalidArgumentException('CMYK engine "imagick" requires ext-imagick and readable RGB/CMYK ICC profile files');
+            }
+            $this->engine = 'imagick-icc';
+        } elseif ($engine === 'math') {
+            $this->engine = 'math';
+        } else {
+            $this->engine = $iccReady ? 'imagick-icc' : 'math';
+            $this->fallback = !$iccReady;
+        }
+
+        if ($this->engine === 'imagick-icc') {
+            $this->rgbProfilePath = $rgb;
+            $this->cmykProfilePath = $cmyk;
+        }
+    }
+
+
+    /**
+     * Преобразува списък RGB цветове към CMYK дялове 0..1, в същия ред.
+     *
+     * @param array $colors list of array(r, g, b), канали 0..255
+     *
+     * @return array list of array(c, m, y, k), дялове 0..1
+     */
+    public function convert(array $colors)
+    {
+        if (!count($colors)) {
+
+            return array();
+        }
+
+        return $this->engine === 'imagick-icc' ? $this->convertIcc($colors) : $this->convertMath($colors);
+    }
+
+
+    /**
+     * Метаданни за одитируемост на резултата (записват се в cmykJson).
+     *
+     * @return array
+     */
+    public function getMetadata()
+    {
+        $source = 'assumed-sRGB';
+        $destination = null;
+        if ($this->engine === 'imagick-icc') {
+            $source = 'assumed-sRGB:' . basename($this->rgbProfilePath) . ':' . md5_file($this->rgbProfilePath);
+            $destination = basename($this->cmykProfilePath) . ':' . md5_file($this->cmykProfilePath);
+        }
+
+        return array(
+            'engine' => $this->engine,
+            'source_profile' => $source,
+            'destination_profile' => $destination,
+            'fallback' => $this->fallback,
+            'version' => self::VERSION,
+        );
+    }
+
+
+    /**
+     * Апроксимативна математическа конверсия (не е точна за печатна преса):
+     *   K = 1 - max(R', G', B'); C = (1-R'-K)/(1-K) и т.н.
+     *
+     * @param array $colors
+     *
+     * @return array
+     */
+    private function convertMath(array $colors)
+    {
+        $result = array();
+        foreach ($colors as $rgb) {
+            $r = $rgb[0] / 255;
+            $g = $rgb[1] / 255;
+            $b = $rgb[2] / 255;
+            $k = 1.0 - max($r, $g, $b);
+            if ($k > 1.0 - 1e-9) {
+                $result[] = array(0.0, 0.0, 0.0, 1.0);
+            } else {
+                $d = 1.0 - $k;
+                $result[] = array((1.0 - $r - $k) / $d, (1.0 - $g - $k) / $d, (1.0 - $b - $k) / $d, $k);
+            }
+        }
+
+        return $result;
+    }
+
+
+    /**
+     * ICC конверсия през Imagick: уникалните цветове се нареждат в канава
+     * 1px висока, тагват се с конфигурирания RGB профил и се конвертират
+     * към конфигурирания CMYK профил (LCMS, rendering intent по подразбиране
+     * на ImageMagick). Цената е по един пиксел на уникален цвят.
+     *
+     * @param array $colors
+     *
+     * @throws RuntimeException при грешка на Imagick
+     *
+     * @return array
+     */
+    private function convertIcc(array $colors)
+    {
+        $n = count($colors);
+        $bytes = '';
+        foreach ($colors as $rgb) {
+            $bytes .= chr($rgb[0]) . chr($rgb[1]) . chr($rgb[2]);
+        }
+
+        try {
+            $img = new Imagick();
+            $img->newImage($n, 1, new ImagickPixel('black'));
+            $img->setImageType(Imagick::IMGTYPE_TRUECOLOR);
+            $img->importImagePixels(0, 0, $n, 1, 'RGB', Imagick::PIXEL_CHAR, $bytes);
+            $img->profileImage('icc', file_get_contents($this->rgbProfilePath));
+            $img->profileImage('icc', file_get_contents($this->cmykProfilePath));
+            $out = $img->exportImagePixels(0, 0, $n, 1, 'CMYK', Imagick::PIXEL_CHAR);
+            $img->clear();
+        } catch (ImagickException $e) {
+            throw new RuntimeException('ICC CMYK conversion failed: ' . $e->getMessage(), 0, $e);
+        }
+
+        $result = array();
+        for ($i = 0; $i < $n; $i++) {
+            $result[] = array(
+                $out[4 * $i] / 255,
+                $out[4 * $i + 1] / 255,
+                $out[4 * $i + 2] / 255,
+                $out[4 * $i + 3] / 255,
+            );
+        }
+
+        return $result;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `php imgcolor/tests/cli_separation.php`
+Expected: `PASS: cli_separation section 1 (converter)` (plus the imagick NOTE locally), exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add imgcolor/CmykConverter.class.php imgcolor/tests/cli_separation.php
+git commit -m "feat(imgcolor): add two-engine RGB-to-CMYK converter"
+```
+
+---
+
+### Task 2: `imgcolor_CmykAccumulator`
+
+**Files:**
+- Create: `imgcolor/CmykAccumulator.class.php`
+- Modify: `imgcolor/tests/cli_separation.php` (append section 2)
+
+**Interfaces:**
+- Consumes: `imgcolor_CmykConverter::convert()` / `getMetadata()` (Task 1); byte constants `imgcolor_TransitionClassifier::CLS_TRANS` etc. (Task 3 — to avoid a forward dependency the byte values are class constants on the accumulator's consumer side; the accumulator receives a classification `stdClass` and compares mask bytes to `"\x03"` via the constant defined in Task 3; for this task's test the stdClass is built by hand and the constant is inlined as `chr(3)`). To keep tasks independent, this task defines the shared constants in a tiny `imgcolor/TransitionClassifier.class.php` *stub* containing only the class constants; Task 3 fills in the methods.
+- Produces: `imgcolor_CmykAccumulator::accumulate(\ImageColorAnalyzer\Contracts\Raster $raster, stdClass $cls, imgcolor_CmykConverter $converter)` returning `?array` (the `cmykJson` payload per spec §8, or null when `$cls->transitionCount == 0`); `$cls` must have `mask` (byte string), `analyzedCount` (int), `transitionCount` (int).
+
+- [ ] **Step 1: Create the constants stub**
+
+Create `imgcolor/TransitionClassifier.class.php` with only the docblock and constants (Task 3 replaces the body):
+
+```php
+<?php
+
+
+/**
+ * Тристепенна пространствена класификация на пикселите за отделяне на
+ * преливки (CMYK) от плътни цветове. Виж
+ * docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.md.
+ *
+ * Без bgERP зависимост - тества се директно с
+ * `php imgcolor/tests/cli_separation.php`.
+ *
+ * @category  bgerp
+ * @package   imgcolor
+ *
+ * @license   GPL 3
+ * @since     v 0.4
+ */
+class imgcolor_TransitionClassifier
+{
+    /**
+     * Класове пиксели - байтови стойности в маската (ред по редове, W*H байта)
+     */
+    const CLS_BG = "\x00";
+    const CLS_SOLID = "\x01";
+    const CLS_AA = "\x02";
+    const CLS_TRANS = "\x03";
+}
+```
+
+- [ ] **Step 2: Append the failing accumulator test (section 2)**
+
+Append to `imgcolor/tests/cli_separation.php` (before the final section-1 `echo`... append after it; each section ends with its own PASS echo):
+
+```php
+// ---------------------------------------------------------------------------
+// 2) CMYK accumulator: alpha weighting, largest-remainder 100.0, zero ink
+// ---------------------------------------------------------------------------
+
+require_once __DIR__ . '/../TransitionClassifier.class.php';
+require_once __DIR__ . '/../CmykAccumulator.class.php';
+
+/**
+ * Builds an InMemoryRaster + hand-made classification over a pixel spec list:
+ * each entry: array(r, g, b, a255, classByte).
+ */
+function accumFixture(array $pixels)
+{
+    $colors = array();
+    $mask = '';
+    foreach ($pixels as $p) {
+        $colors[] = new \ImageColorAnalyzer\Contracts\ColorRGBA($p[0], $p[1], $p[2], $p[3]);
+        $mask .= $p[4];
+    }
+    $raster = new \ImageColorAnalyzer\ImageLoader\InMemoryRaster(count($pixels), 1, $colors);
+    $cls = new stdClass();
+    $cls->mask = $mask;
+    $cls->analyzedCount = 0;
+    $cls->transitionCount = 0;
+    foreach ($pixels as $p) {
+        if ($p[4] !== imgcolor_TransitionClassifier::CLS_BG) {
+            $cls->analyzedCount++;
+        }
+        if ($p[4] === imgcolor_TransitionClassifier::CLS_TRANS) {
+            $cls->transitionCount++;
+        }
+    }
+
+    return array($raster, $cls);
+}
+
+$T = imgcolor_TransitionClassifier::CLS_TRANS;
+$S = imgcolor_TransitionClassifier::CLS_SOLID;
+$B = imgcolor_TransitionClassifier::CLS_BG;
+
+// no transitions -> null
+list($raster, $cls) = accumFixture(array(array(10, 20, 30, 255, $S)));
+if (imgcolor_CmykAccumulator::accumulate($raster, $cls, $math) !== null) {
+    fail('no transitions must yield null');
+}
+
+// pure red + pure cyan-ish transitions, solid pixel excluded, composition sums to 100.0
+list($raster, $cls) = accumFixture(array(
+    array(255, 0, 0, 255, $T),   // math: C0 M1 Y1 K0
+    array(0, 255, 255, 255, $T), // math: C1 M0 Y0 K0
+    array(0, 0, 0, 255, $S),     // solid: excluded (would add K)
+    array(0, 0, 0, 255, $B),     // background: excluded
+));
+$res = imgcolor_CmykAccumulator::accumulate($raster, $cls, $math);
+if ($res === null) {
+    fail('transitions present must yield a result');
+}
+$sum = $res['composition_percent']['c'] + $res['composition_percent']['m']
+     + $res['composition_percent']['y'] + $res['composition_percent']['k'];
+approx($sum, 100.0, 0.001, 'composition must sum to exactly 100.0');
+approx($res['composition_percent']['c'], 33.3, 0.11, 'cyan share');
+approx($res['composition_percent']['k'], 0.0, 0.001, 'solid black pixel must not leak into K');
+approx($res['transition_coverage_percent'], 66.7, 0.11, 'coverage = 2 of 3 analyzed');
+approx($res['ink_total'], 3.0, 0.001, 'raw ink total');
+if ($res['conversion']['engine'] !== 'math') {
+    fail('conversion metadata must be embedded');
+}
+
+// alpha weighting: half-transparent red deposits half the ink of opaque red
+list($raster, $cls) = accumFixture(array(
+    array(255, 0, 0, 255, $T),
+    array(255, 0, 0, 128, $T),
+));
+$res = imgcolor_CmykAccumulator::accumulate($raster, $cls, $math);
+approx($res['ink_total'], 2 * (1 + 128 / 255), 0.01, 'alpha-weighted ink total');
+
+// zero ink: white-only transition reports zeros, no division by zero
+list($raster, $cls) = accumFixture(array(array(255, 255, 255, 200, $T)));
+$res = imgcolor_CmykAccumulator::accumulate($raster, $cls, $math);
+if ($res['ink_total'] != 0.0) {
+    fail('white transition must accumulate zero ink');
+}
+foreach (array('c', 'm', 'y', 'k') as $ch) {
+    if ($res['composition_percent'][$ch] !== 0.0) {
+        fail('zero-ink composition must be all zeros');
+    }
+}
+approx($res['transition_coverage_percent'], 100.0, 0.001, 'zero-ink coverage still reported');
+
+echo "PASS: cli_separation section 2 (accumulator)\n";
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `php imgcolor/tests/cli_separation.php`
+Expected: fatal error, `Failed opening required '.../CmykAccumulator.class.php'`
+
+- [ ] **Step 4: Implement the accumulator**
+
+Create `imgcolor/CmykAccumulator.class.php`:
+
+```php
+<?php
+
+
+/**
+ * CMYK акумулатор върху преливките: групира TRANSITION пикселите по цвят,
+ * конвертира уникалните цветове (imgcolor_CmykConverter), натрупва мастилата
+ * с тегло alpha/255 и нормализира състава до точно 100.0% по метода на
+ * най-големия остатък (както PercentageCoverageCalculator на библиотеката).
+ *
+ * Без bgERP зависимост - тества се директно с
+ * `php imgcolor/tests/cli_separation.php`.
+ *
+ * @category  bgerp
+ * @package   imgcolor
+ *
+ * @license   GPL 3
+ * @since     v 0.4
+ */
+class imgcolor_CmykAccumulator
+{
+    /**
+     * Натрупва CMYK резултата за TRANSITION пикселите на растера.
+     *
+     * @param \ImageColorAnalyzer\Contracts\Raster $raster    изрязаният растер
+     * @param stdClass                             $cls       резултат от imgcolor_TransitionClassifier::classify()
+     * @param imgcolor_CmykConverter               $converter
+     *
+     * @return array|null null когато няма преливки; иначе payload за cmykJson
+     */
+    public static function accumulate($raster, $cls, imgcolor_CmykConverter $converter)
+    {
+        if (empty($cls->transitionCount)) {
+
+            return null;
+        }
+
+        // Групиране по 24-битов RGB ключ: тегло = сума alpha/255
+        $bins = array();
+        $i = 0;
+        foreach ($raster->pixels() as $px) {
+            if ($cls->mask[$i++] !== imgcolor_TransitionClassifier::CLS_TRANS) {
+                continue;
+            }
+            $key = ($px->r << 16) | ($px->g << 8) | $px->b;
+            $bins[$key] = (isset($bins[$key]) ? $bins[$key] : 0.0) + $px->a / 255;
+        }
+
+        // Каноничен ред за детерминизъм, независим от реда на срещане
+        ksort($bins);
+
+        $colors = array();
+        foreach ($bins as $key => $weight) {
+            $colors[] = array(($key >> 16) & 0xFF, ($key >> 8) & 0xFF, $key & 0xFF);
+        }
+
+        $cmyk = $converter->convert($colors);
+
+        $raw = array('c' => 0.0, 'm' => 0.0, 'y' => 0.0, 'k' => 0.0);
+        $j = 0;
+        foreach ($bins as $weight) {
+            $raw['c'] += $cmyk[$j][0] * $weight;
+            $raw['m'] += $cmyk[$j][1] * $weight;
+            $raw['y'] += $cmyk[$j][2] * $weight;
+            $raw['k'] += $cmyk[$j][3] * $weight;
+            $j++;
+        }
+
+        $inkTotal = $raw['c'] + $raw['m'] + $raw['y'] + $raw['k'];
+
+        // Изрично дефиниран нулев случай (напр. само-бяла преливка): нули,
+        // без деление - процентният състав няма смисъл без мастило.
+        $percent = array('c' => 0.0, 'm' => 0.0, 'y' => 0.0, 'k' => 0.0);
+        if ($inkTotal > 0) {
+            $percent = self::normalizePercent($raw, $inkTotal);
+        }
+
+        $rounded = array();
+        foreach ($raw as $ch => $v) {
+            $rounded[$ch] = round($v, 3);
+        }
+
+        return array(
+            'transition_coverage_percent' => round($cls->transitionCount / $cls->analyzedCount * 100, 1),
+            'composition_percent' => $percent,
+            'ink_total' => round($inkTotal, 3),
+            'raw_channels' => $rounded,
+            'conversion' => $converter->getMetadata(),
+        );
+    }
+
+
+    /**
+     * Най-голям остатък в десети от процента: четирите стойности сумират
+     * точно до 100.0 (1000 десети), без "99.9%" артефакти.
+     *
+     * @param array $raw      натрупани канали
+     * @param float $inkTotal сума на каналите (> 0)
+     *
+     * @return array
+     */
+    private static function normalizePercent(array $raw, $inkTotal)
+    {
+        $tenths = array();
+        $remainders = array();
+        $allocated = 0;
+        foreach ($raw as $ch => $v) {
+            $exact = $v / $inkTotal * 1000;
+            $floor = (int) floor($exact);
+            $tenths[$ch] = $floor;
+            $remainders[$ch] = $exact - $floor;
+            $allocated += $floor;
+        }
+
+        $order = array_keys($remainders);
+        usort($order, function ($a, $b) use ($remainders) {
+            $byRemainder = $remainders[$b] <=> $remainders[$a];
+
+            return $byRemainder !== 0 ? $byRemainder : strcmp($a, $b);
+        });
+
+        for ($i = 0; $i < 1000 - $allocated; $i++) {
+            $tenths[$order[$i]]++;
+        }
+
+        $percent = array();
+        foreach ($tenths as $ch => $t) {
+            $percent[$ch] = $t / 10.0;
+        }
+
+        return $percent;
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `php imgcolor/tests/cli_separation.php`
+Expected: sections 1 and 2 PASS, exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add imgcolor/CmykAccumulator.class.php imgcolor/TransitionClassifier.class.php imgcolor/tests/cli_separation.php
+git commit -m "feat(imgcolor): add alpha-weighted CMYK accumulator with exact-100 normalization"
+```
+
+---
+
+### Task 3: `imgcolor_TransitionClassifier` (full algorithm)
+
+**Files:**
+- Modify: `imgcolor/TransitionClassifier.class.php` (replace stub body)
+- Modify: `imgcolor/tests/cli_separation.php` (append section 3 + fixture helpers)
+
+**Interfaces:**
+- Consumes: `\ImageColorAnalyzer\Contracts\Raster` (`width()`, `height()`, `pixels()`), `\ImageColorAnalyzer\Color\ColorConverter::rgbToLab()`.
+- Produces: `imgcolor_TransitionClassifier::normalizeParams(array $params)` → validated array (defaults merged; throws `InvalidArgumentException` naming the field); `::classify(Raster $raster, array $params)` → `stdClass{mask:string, width:int, height:int, analyzedCount:int, solidCount:int, aaCount:int, transitionCount:int}`; `::renderMaskPng(stdClass $cls)` → PNG bytes (debug: solid gray, AA red, transition blue, background transparent); class constants `CLS_BG|CLS_SOLID|CLS_AA|CLS_TRANS` and `$defaults`.
+
+Algorithm (spec §4, validated in prototype): stage 1 coherent-drift CHANGING mask over a rolling 2·span+1 row window of packed ARGB ints (Lab memo capped at 65536 entries; alpha as 4th component scaled ×100/255); stage 2 erosion via sliding box counts (seed ⇔ CHANGING center, zero SOLID in (2r+1)² window, ≥minSeed CHANGING); stage 3 BFS 8-connected reconstruction across CHANGING, blocked where a pixel's max 4-neighbor ΔE exceeds edgeDeltaE (blocked pixels memoized with a temp byte so they are tested once); stage 4 coverage guard (below minCoverage → all TRANS→AA via strtr). Full pixel data kept as a `pack('N*')` binary string (4 bytes/px) for random access during flood.
+
+- [ ] **Step 1: Append failing classifier tests (section 3) with fixture generators** — the complete code for the section, including `mkImg/setPx/lerpc/aaDisk/jpegRoundtrip/rasterOf/classifyStats` helpers and assertions for: solid single (0% trans), solid multi hard edges (0%), AA disk on white and on transparent (0%), 1px/2px AA ramps (0%), blurred edge (0%), JPEG q60 flat (0%), JPEG q55 ringing (0%), linear gradient (>85%), diagonal (>90%), gray (>85%), multi-stop (>85%), radial (>70%), steep 16px band (partial, >40% of band), alpha fades white/color (>85%), sub-coverage 10×10 gradient (0% after guard), mixed scene (gradient band >85%, false-transition in solid zones <1%), tiny 3×3 and 1×1 images (all solid, no errors), invalid params rejected. Exact code is in the repository test file after implementation; tolerances per prototype measurements ±5pp.
+- [ ] **Step 2: Run to verify failure** — `php imgcolor/tests/cli_separation.php` → fatal: call to undefined method `classify()`.
+- [ ] **Step 3: Implement `classify()`/`normalizeParams()`/`renderMaskPng()`** per the algorithm above (full implementation, see spec §4 for stage semantics and defaults table).
+- [ ] **Step 4: Run to verify pass** — all sections PASS.
+- [ ] **Step 5: Commit** — `feat(imgcolor): add three-way transition classifier`
+
+---
+
+### Task 4: `imgcolor_MaskedRaster` + solid-path byte parity
+
+**Files:**
+- Create: `imgcolor/MaskedRaster.class.php`
+- Modify: `imgcolor/tests/cli_separation.php` (append section 4)
+
+**Interfaces:**
+- Consumes: `imgcolor_TransitionClassifier::CLS_TRANS`, library `Raster`/`BoundingBox`/`ColorRGBA`/`NotImplementedException`.
+- Produces: `new imgcolor_MaskedRaster(Raster $raster, string $mask, string $skipByte = imgcolor_TransitionClassifier::CLS_TRANS)`; `pixels()` yields only non-skipped pixels (so `ColorHistogram` totals = solid+AA count); `width/height/hasAlpha/pixelAt` delegate; `crop()` throws `NotImplementedException`. Constructor throws `InvalidArgumentException` when `strlen($mask) !== width*height`.
+
+```php
+<?php
+
+
+/**
+ * Raster декоратор, който скрива класифицираните като преливка пиксели от
+ * pixels() итерацията, за да ги изключи от съществуващото клъстеризиране
+ * (ColorHistogram консумира само pixels()). Използва се единствено когато
+ * има намерени преливки - иначе оригиналният растер се подава директно и
+ * пътят на плътните цветове е байт-идентичен с досегашния.
+ *
+ * @category  bgerp
+ * @package   imgcolor
+ *
+ * @license   GPL 3
+ * @since     v 0.4
+ */
+class imgcolor_MaskedRaster implements \ImageColorAnalyzer\Contracts\Raster
+{
+    private $raster;
+    private $mask;
+    private $skipByte;
+
+
+    /**
+     * @param \ImageColorAnalyzer\Contracts\Raster $raster
+     * @param string                               $mask     байтова маска W*H (imgcolor_TransitionClassifier)
+     * @param string                               $skipByte кой клас да се скрие
+     */
+    public function __construct(\ImageColorAnalyzer\Contracts\Raster $raster, $mask, $skipByte = imgcolor_TransitionClassifier::CLS_TRANS)
+    {
+        if (strlen($mask) !== $raster->width() * $raster->height()) {
+            throw new InvalidArgumentException('Mask length must equal raster width*height');
+        }
+        $this->raster = $raster;
+        $this->mask = $mask;
+        $this->skipByte = $skipByte;
+    }
+
+
+    public function width(): int
+    {
+        return $this->raster->width();
+    }
+
+
+    public function height(): int
+    {
+        return $this->raster->height();
+    }
+
+
+    public function hasAlpha(): bool
+    {
+        return $this->raster->hasAlpha();
+    }
+
+
+    /**
+     * Достъп по координати - без маскиране; маската важи само за pixels().
+     */
+    public function pixelAt(int $x, int $y): \ImageColorAnalyzer\Contracts\ColorRGBA
+    {
+        return $this->raster->pixelAt($x, $y);
+    }
+
+
+    /**
+     * @return iterable<\ImageColorAnalyzer\Contracts\ColorRGBA>
+     */
+    public function pixels(): iterable
+    {
+        $i = 0;
+        foreach ($this->raster->pixels() as $pixel) {
+            if ($this->mask[$i++] === $this->skipByte) {
+                continue;
+            }
+            yield $pixel;
+        }
+    }
+
+
+    public function crop(\ImageColorAnalyzer\Contracts\BoundingBox $box): \ImageColorAnalyzer\Contracts\Raster
+    {
+        throw new \ImageColorAnalyzer\Exception\NotImplementedException('imgcolor_MaskedRaster does not support cropping');
+    }
+}
+```
+
+Section 4 tests: (a) masked histogram total equals unmasked total minus masked count on a synthetic raster; (b) **byte parity** — for the solid-multi and AA-disk fixtures plus `tests/fixtures/sample.png`, JSON from the legacy library facade equals JSON from the (Task 5) separated path; deferred to section 5 where the orchestrator exists — section 4 asserts parity at the histogram level: `ColorHistogram::build()` on original raster vs on a `MaskedRaster` with an all-`CLS_SOLID` mask produces identical arrays (proves the decorator is transparent when nothing is skipped — though the orchestrator bypasses it anyway).
+
+Steps: failing test → implement → pass → commit `feat(imgcolor): add mask-aware raster decorator`.
+
+---
+
+### Task 5: `imgcolor_Separation` orchestrator
+
+**Files:**
+- Create: `imgcolor/Separation.class.php`
+- Modify: `imgcolor/tests/cli_separation.php` (append section 5 + performance probe)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4; library `WhiteBackgroundCropper`, `KMeansClusterer`, `ColorHistogram`, `KSelector`, `PercentageCoverageCalculator`, `AnalyzerOptions`.
+- Produces: `imgcolor_Separation::process(Raster $raster, \ImageColorAnalyzer\Options\AnalyzerOptions $options, array $transParams, imgcolor_CmykConverter $converter)` → `stdClass{colors:array, cmyk:?array, crop:\ImageColorAnalyzer\Contracts\CropResult, classification:stdClass}`. `$transParams['alphaThreshold']` is forced to `$options->cluster->alphaThreshold` so BACKGROUND matches the histogram skip rule.
+
+```php
+<?php
+
+
+/**
+ * bgERP-независим оркестратор на разделния анализ: изрязване (библиотечен
+ * cropper) -> класификация на преливките -> клъстеризиране на плътните
+ * цветове (непроменен библиотечен път; при липса на преливки оригиналният
+ * растер се подава директно за байт-идентичен резултат) -> CMYK акумулация.
+ *
+ * Тества се директно с `php imgcolor/tests/cli_separation.php`.
+ *
+ * @category  bgerp
+ * @package   imgcolor
+ *
+ * @license   GPL 3
+ * @since     v 0.4
+ */
+class imgcolor_Separation
+{
+    /**
+     * @param \ImageColorAnalyzer\Contracts\Raster        $raster     зареден (незакрит) растер
+     * @param \ImageColorAnalyzer\Options\AnalyzerOptions $options
+     * @param array                                       $transParams прагове за imgcolor_TransitionClassifier
+     * @param imgcolor_CmykConverter                      $converter
+     *
+     * @return stdClass {colors, cmyk, crop, classification}
+     */
+    public static function process($raster, $options, array $transParams, imgcolor_CmykConverter $converter)
+    {
+        $libConverter = new \ImageColorAnalyzer\Color\ColorConverter();
+
+        $cropper = new \ImageColorAnalyzer\WhiteBackgroundCropper\WhiteBackgroundCropper($libConverter);
+        $crop = $cropper->crop($raster, $options->crop);
+
+        // BACKGROUND дефиницията следва прага на клъстеризирането, за да
+        // съвпада с досегашното изключване на прозрачни пиксели.
+        $transParams['alphaThreshold'] = $options->cluster->alphaThreshold;
+        $classification = imgcolor_TransitionClassifier::classify($crop->raster, $transParams);
+
+        $clusterInput = $classification->transitionCount > 0
+            ? new imgcolor_MaskedRaster($crop->raster, $classification->mask)
+            : $crop->raster;
+
+        $clusterer = new \ImageColorAnalyzer\ColorClusterer\KMeansClusterer(
+            $libConverter,
+            new \ImageColorAnalyzer\ColorClusterer\ColorHistogram(),
+            new \ImageColorAnalyzer\ColorClusterer\KSelector($libConverter)
+        );
+        $clusters = $clusterer->cluster($clusterInput, $options->cluster);
+
+        $colors = array();
+        $coverage = new \ImageColorAnalyzer\CoverageCalculator\PercentageCoverageCalculator();
+        foreach ($coverage->calculate($clusters) as $item) {
+            $colors[] = $item->toArray();
+        }
+
+        $result = new stdClass();
+        $result->colors = $colors;
+        $result->cmyk = imgcolor_CmykAccumulator::accumulate($crop->raster, $classification, $converter);
+        $result->crop = $crop;
+        $result->classification = $classification;
+
+        return $result;
+    }
+}
+```
+
+Section 5 tests: solid-only fixture and `fixtures/sample.png` — `json_encode($sep->colors, JSON_THROW_ON_ERROR|JSON_PRETTY_PRINT|JSON_PRESERVE_ZERO_FRACTION)` byte-equals `AnalyzerFactory::createDefault()->analyzePathAsJson()` and `cmyk === null`; `fixtures/sample_transparent.png` parity; mixed fixture — solid list contains green/gray/blue solids but no gradient centroids (every reported color within ΔE 10 of an expected solid), `cmyk` non-null, composition sums 100.0, coverage 25–40%; gradient-only fixture — colors list may be small/empty but `cmyk` covers >85%; fully transparent → colors `[]`, cmyk null; determinism — two runs produce identical serialized results; performance probe on 1200×800 mixed (report seconds + peak MB, no hard assert).
+
+Steps: failing test → implement → pass → commit `feat(imgcolor): add bgERP-free separation orchestrator`.
+
+---
+
+### Task 6: Config constants + `imgcolor_Analyzer::processSeparated()`
+
+**Files:**
+- Modify: `imgcolor/Setup.class.php` (constants, configDescription, version 0.3→0.4, checkConfig)
+- Modify: `imgcolor/Analyzer.class.php` (add `getTransParams()`, `getCmykConfig()`, `processSeparated()`)
+
+**Interfaces:**
+- Consumes: `imgcolor_Separation::process()` (Task 5), `imgcolor_TransitionClassifier::normalizeParams()` (Task 3), `imgcolor_CmykConverter` (Task 1).
+- Produces: `imgcolor_Analyzer::processSeparated($source, $options = null)` → `stdClass{json:string, cmykJson:?string, croppedImage:\ImageColorAnalyzer\Contracts\EncodedImage, boundingBox, wasCropped:bool}`; `imgcolor_Analyzer::getTransParams()` → array for the classifier; `imgcolor_Analyzer::getCmykConfig()` → array for the converter. New constants `IMGCOLOR_TRANS_SPAN=4`, `IMGCOLOR_TRANS_NOISE_DELTAE=1.0`, `IMGCOLOR_TRANS_COHERENCE_MIN=0.4`, `IMGCOLOR_TRANS_AA_RADIUS=3`, `IMGCOLOR_TRANS_MIN_SEED=20`, `IMGCOLOR_TRANS_EDGE_DELTAE=10.0`, `IMGCOLOR_TRANS_MIN_COVERAGE=0.005`, `IMGCOLOR_CMYK_ENGINE='auto'`, `IMGCOLOR_CMYK_ICC_RGB_PROFILE=''`, `IMGCOLOR_CMYK_ICC_CMYK_PROFILE=''` with configDescription captions (Bulgarian, groups «Преливки» and «CMYK»). `checkConfig()` additionally validates `normalizeParams(getTransParams())` and `new imgcolor_CmykConverter(getCmykConfig())`.
+
+`processSeparated()` (full code): registerAutoload + requireGd; resolve options (`buildOptions()` default); build loader per `IMGCOLOR_LOADER`; `SourceResolver->resolve($source)`; `imgcolor_Separation::process(...)`; encode cropped PNG via `GdPngEncoder`; JSON with `JSON_THROW_ON_ERROR|JSON_PRETTY_PRINT|JSON_PRESERVE_ZERO_FRACTION` for colors (byte parity with library), `JSON_THROW_ON_ERROR|JSON_PRESERVE_ZERO_FRACTION` for cmyk; translate `ImageAnalyzerException`, `InvalidArgumentException`, `RuntimeException` through `raiseError()`.
+
+Steps: implement → `php -l` both files → run full CLI suite → commit `feat(imgcolor): wire separated analysis into wrapper config and service`.
+
+---
+
+### Task 7: Persistence + UI (`imgcolor_Analyses`, `imgcolor_Demo`) + web tests
+
+**Files:**
+- Modify: `imgcolor/Analyses.class.php` (add `cmykJson` FLD after `colorsJson`; `createFromResult(..., $cmykJson = null)`; `renderRec()` passes it)
+- Modify: `imgcolor/Demo.class.php` (`act_Analyze`/`act_AnalyzeColors` call `processSeparated()`; `renderColorsHtml($colorsJson, $croppedImageBytes = null, $cmykJson = null)` renders a «CMYK преливки» block: coverage line, four labeled bars C/M/Y/K with percentages and engine note; `renderResult()`/`persistResult()` pass `->cmykJson`)
+- Create: `imgcolor/tests/Separation.class.php` (`imgcolor_tests_Separation extends unit_Class`, web runner): parity of `processSeparated()->json` with `analyzePathAsJson()` on `fixtures/sample.png`; persistence round-trip of `cmykJson` through `imgcolor_Analyses::createFromResult()`/`renderRec()` (output contains `CMYK` section for a gradient fixture, not for a solid one); `createFromResult()` without the new argument still works.
+
+New field definition: `$this->FLD('cmykJson', 'text', 'caption=CMYK преливки (JSON),input=none');` — bgERP syncs added fields on package setup/migration automatically; version bump in Task 6 triggers it.
+
+Steps: implement → `php -l` all touched files → run CLI suite (unchanged green) → commit `feat(imgcolor): persist and render CMYK transition result`.
+
+---
+
+### Task 8: Documentation + full validation
+
+**Files:**
+- Modify: `imgcolor/docs/integration.md` (new sections: separated analysis entry point, cmykJson schema, config table for `IMGCOLOR_TRANS_*`/`IMGCOLOR_CMYK_*` with units/defaults/effects, ICC profile installation note — obtain e.g. ECI ISOcoated_v2_300 separately, semantics change note for gradient images, test commands)
+- Modify: `imgcolor/tests/cli_separation.php` if validation finds gaps
+
+Steps: update docs → run all six CLI tests → record results, performance numbers, and untested paths (Imagick ICC, web unit tests) → commit `docs(imgcolor): document CMYK separation integration`.
+
+## Self-Review Notes
+
+- Spec coverage: §3–§4 → Task 3; §5 alpha/§6 rules → Tasks 3+2; §7 → Task 1; §8 → Task 2; §9 → Task 6; §10 components → Tasks 1–6; §11 perf probe → Task 5; §12 tests → Tasks 1–5, 7; §13 docs → Task 8. No gaps.
+- Type consistency: `classification` stdClass fields (`mask/analyzedCount/transitionCount`) used identically in Tasks 2, 3, 5; converter cfg keys (`engine/rgbProfile/cmykProfile`) identical in Tasks 1 and 6.
+- Task 3 Step 1/3 carry the algorithm by reference to spec §4 (stages, defaults, data structures) rather than inline code — the spec table is the single source of truth for thresholds; all other tasks carry complete code.

--- a/docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.md
+++ b/docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.md
@@ -1,0 +1,360 @@
+# imgcolor: CMYK separation of transitions (преливки) — design
+
+Date: 2026-07-13
+Status: approved direction (Approach C, hybrid three-way classification), refined
+against prototype measurements.
+
+## 1. Business requirement and settled semantics
+
+Original: "Да отделим CMYK, т.е. да останат плътните цветове. Само преливките да
+останат на CMYK. Когато е CMYK, изчисляваме колко е процента на четирите вида
+цвята и ги събираме в акумулатор, който показва процентното съдържание на
+подцветовете на CMYK."
+
+Decisions settled with the requester:
+
+1. **True separation.** Transition (gradient) pixels are excluded from the
+   solid-color clustering. The existing color list reports only genuine solids;
+   the new CMYK result covers only the transition area. Images without genuine
+   transitions must keep today's solid output unchanged.
+2. **CMYK output = normalized ink composition.** `C% + M% + Y% + K% = 100` over
+   the accumulated ink of the transition area. Raw channel totals are kept in
+   the result for auditability. Transition *area* coverage is reported
+   separately so a small gradient is not presented as the whole image.
+3. **Anti-aliased edge pixels are not transitions.** They remain in the solid
+   path and are absorbed by the existing cluster merge machinery
+   (`KMeansClusterer::mergeByDeltaE()` / `foldLowCoverage()`).
+4. **Conversion quality over zero-dependency.** ICC-based conversion through
+   Imagick when available and configured; documented mathematical conversion as
+   fallback. No third-party ICC profile is bundled silently — profile paths are
+   configuration; without them the math engine is used and recorded.
+5. **Storage/UI.** New `cmykJson` text field on `imgcolor_Analyses`, new result
+   section in `imgcolor_Demo`. Existing `colorsJson` schema and the LLM tool
+   contract (`analyze_image_print_colors`) are unchanged.
+
+## 2. Repository integration evidence
+
+- `imgcolor_Analyzer` (imgcolor/Analyzer.class.php) is the only entry to the
+  vendored library and already hand-wires the six pipeline components for the
+  Imagick loader case (`makeAnalyzer()`), so wrapper-side orchestration of
+  loader → cropper → classifier → clusterer → coverage is an established
+  pattern.
+- The vendored library under `imgcolor/lib/image-color-analyzer/` stays
+  untouched ("Never edit files under lib/", docs/integration.md). New code
+  consumes its public contracts: `Raster`, `ColorRGBA`, `ColorConverter`,
+  `ColorHistogram`, `KMeansClusterer`, `PercentageCoverageCalculator`,
+  `GdPngEncoder`, `WhiteBackgroundCropper`.
+- Solid colors today are k-means clusters over a weighted RGB histogram
+  (`ColorHistogram::build()` skips pixels with `alpha < alphaThreshold`,
+  weights are pixel counts). The "existing color table" is the JSON list
+  `[{color, coverage_percent}]` persisted in `imgcolor_Analyses.colorsJson`.
+- There is no CMYK logic anywhere in the repository; CMYK JPEG input is
+  explicitly rejected (`GdImageLoader::rejectUnsupportedJpeg()`).
+- `ColorConverter` provides deterministic sRGB↔Lab (D65) and CIE76/CIE94
+  delta-E. CIE76 is what the clusterer uses; the classifier uses the same
+  metric for consistency (see §5 "Color difference").
+
+## 3. Pixel classes — final semantics
+
+Every pixel of the cropped raster gets exactly one class:
+
+- **BACKGROUND** — `alpha < clusterAlphaThreshold` (default 8). Contributes to
+  nothing, exactly like today's histogram behavior.
+- **SOLID** — analyzed pixel whose local neighborhood shows no coherent color
+  drift (see §4). Goes to the existing clustering path.
+- **AA/EDGE** — analyzed pixel that changes locally but does not belong to a
+  reconstructed transition region: anti-alias ramps (1–2 px), hard edge
+  fringes, blurred edges up to ~2r px wide, JPEG ringing/block noise. Goes to
+  the existing clustering path, where merge/fold absorbs it into its solid —
+  the same place those pixels end up today.
+- **TRANSITION** — analyzed pixel inside a coherent, spatially extended color
+  ramp (linear/radial/multi-stop/irregular gradient, continuous-tone or
+  photographic content, alpha fades). Excluded from clustering; accumulated
+  into the CMYK result.
+
+How specific inputs classify (validated by prototype fixtures):
+
+| Input                          | Class outcome                                   |
+|--------------------------------|-------------------------------------------------|
+| Smooth gradient (any shape)    | TRANSITION (93–99% of area)                     |
+| Hard edge between solids       | AA/EDGE (band ≈ sampling span)                  |
+| 1–2 px anti-alias ramp         | AA/EDGE (0% false transition)                   |
+| JPEG ringing / block noise     | SOLID or AA/EDGE (coherence test rejects it)    |
+| Resampling blur ≤ ~6 px        | AA/EDGE (erosion radius kills narrow bands)     |
+| Shadow / soft glow             | TRANSITION if wide and coherent — correct: it   |
+|                                | cannot be printed as a spot color               |
+| Alpha fade (color→transparent) | TRANSITION (alpha is a 4th channel, §6)         |
+| Photograph / texture           | TRANSITION — correct for print separation       |
+| Gradient < min coverage        | folded back to AA/EDGE by the guard             |
+
+## 4. Classifier algorithm (selected variant)
+
+Variants measured on 22 synthetic fixtures with ground truth (prototype,
+scratchpad): V1 dual-threshold + adjacency cleanup; V2 erosion+reconstruction;
+V3 = V2 + hard-edge flood barrier; V4 = V3 with a *directional coherence* test
+replacing the plain magnitude test. V1 missed steep gradients and let 25% of a
+q60 JPEG through; V2/V3 leaked 9–56% on blurred edges and JPEG; V4 scored 0%
+false transitions on every solid/AA/JPEG fixture while keeping 93–99% recall on
+all gradient families. V4 is selected.
+
+Stage 1 — coherent drift ("CHANGING") mask, one pass, rolling 2s+1 row window:
+
+For each analyzed pixel `p` and each axis (horizontal, vertical), take the
+samples at distance `s` on both sides (skip the axis if either sample is
+outside the image or BACKGROUND). With `F(q) = [L*, a*, b*, alpha/255*100]`:
+
+    v1 = F(p) − F(p−s),  v2 = F(p+s) − F(p)
+    magnitude  = (|v1| + |v2|) / 2
+    coherence  = (v1·v2) / (|v1|·|v2|)
+    axis is drifting  ⇔  magnitude ≥ noiseFloor  AND  coherence ≥ cosMin
+
+`p` is CHANGING iff at least one axis drifts. Rationale: gradient steps
+accumulate linearly with `s` and keep direction; JPEG noise, ringing and block
+steps have random or opposing local directions and fail `cosMin`, and pixels
+flanking a hard edge fail it too (one side is flat), which keeps the CHANGING
+band tight around real ramps.
+
+Stage 2 — erosion: a CHANGING pixel is a *seed* iff its (2r+1)² Chebyshev
+window contains no SOLID analyzed pixel and at least `minSeed` CHANGING pixels.
+Kills bands narrower than 2r+1 px (AA ramps, blurred edges, leftover noise
+specks). Implemented with sliding column counts, O(N).
+
+Stage 3 — reconstruction: 8-connected flood from seeds across CHANGING pixels,
+blocked at pixels whose max 4-neighbor (span-1) difference exceeds `edgeCap`
+(prevents leaking along connected AA outlines and across hard boundaries).
+Non-reached CHANGING pixels become AA/EDGE.
+
+Stage 4 — coverage guard: if `transitionCount / analyzedCount < minCoverage`,
+all TRANSITION pixels are reclassified AA/EDGE and the CMYK result is empty.
+
+Defaults (calibrated on the prototype fixture set, all configurable, §9):
+
+| Parameter  | Default | Units                | Effect / rationale                                              |
+|------------|---------|----------------------|-----------------------------------------------------------------|
+| span s     | 4       | px                   | Signal gain ×4 vs noise; detectability bound ≈ floor/s ΔE/px    |
+| noiseFloor | 1.0     | ΔE (CIE76+alpha)     | Below: SOLID. 1.0 catches ≥0.3 ΔE/px slopes, ignores dithering  |
+| cosMin     | 0.4     | cosine               | 0.2 left 2.4% JPEG false transitions; 0.4 → 0% with no recall loss |
+| r          | 3       | px                   | Min gradient core width 2r+1=7 px; r=4 killed a real 16px ramp  |
+| minSeed    | 20      | px count             | Of 49-px window; rejects sparse speckle seeds                   |
+| edgeCap    | 10.0    | ΔE                   | Flood barrier; ~2× a JND above any in-gradient per-px step      |
+| minCoverage| 0.005   | fraction             | 10×10 gradient in 200×200 solid folds away; real gradients pass |
+
+Known, accepted limitations (documented, tested as such): slopes below
+~0.3 ΔE/px read as SOLID (graceful: they cluster as близки solids); transition
+bands narrower than 7 px fold to AA/EDGE; the flat extremum ring of radial
+gradients and the last ~s px at gradient ends read as AA/EDGE (recall 76–99%,
+solids win ties by design).
+
+## 5. Color difference choice
+
+CIE76 over Lab, same as the clustering pipeline (`ColorConverter::deltaE()`),
+extended with alpha as a fourth component scaled to percent
+(`Δalpha/255*100`). CIE94 exists in the converter but weights chroma
+differences *down*, which would only lower gradient recall in chromatic ramps;
+the classifier compares *neighboring* (perceptually close) colors where CIE76
+is adequate. Prototype scores confirmed no need for a costlier metric.
+
+Lab values are memoized per packed 24-bit RGB with a hard cap (2^16 entries,
+mirroring `WhiteBackgroundCropper::MEMO_CAP`); colors beyond the cap are
+computed uncached — correct, just slower on adversarial many-color inputs.
+
+## 6. Transparency rules
+
+- `alpha < clusterAlphaThreshold` (default 8): BACKGROUND everywhere — not
+  classified, not clustered, not accumulated; identical to today's histogram
+  skip rule.
+- `alpha ≥ threshold`: the pixel is analyzed. Classification treats alpha as a
+  4th color channel, so color-constant alpha ramps classify as TRANSITION and
+  abrupt alpha edges (AA on transparent background) classify as AA/EDGE.
+- Solid path: unchanged — analyzed pixels enter the histogram at full weight
+  regardless of partial alpha (existing behavior, preserved for parity).
+- CMYK accumulation: pixel weight = `alpha / 255` (a 50%-transparent pixel
+  deposits half the ink). Classification weight is discrete (1 for TRANSITION,
+  0 otherwise) — prototype showed no need for confidence weighting.
+- GD provides straight (non-premultiplied) alpha; 7-bit GD alpha is already
+  expanded to 0–255 by `GdRaster::colorAt()`. Indexed transparency is
+  normalized to RGBA by `GdImageLoader::normalizeTruecolorWithAlpha()`.
+- Fully transparent image: everything BACKGROUND → empty solid list (as today)
+  and empty CMYK result.
+
+## 7. RGB→CMYK conversion
+
+Engine selection (`IMGCOLOR_CMYK_ENGINE`):
+
+- `auto` (default): use ICC when the Imagick extension is loaded **and** both
+  profile paths are configured and readable; otherwise math.
+- `imagick`: require the ICC path, error loudly if unavailable.
+- `math`: always use the formula.
+
+ICC path: unique transition colors (histogram-binned, so hundreds not
+millions) are written into a small Imagick canvas, tagged with the configured
+RGB source profile, converted with `profileImage()` to the configured CMYK
+profile (LCMS relative-colorimetric by ImageMagick default), and read back as
+0–1 CMYK fractions. Embedded source profiles are *not* honored in v1: the GD
+decode path has already stripped them, and the whole pipeline (crop, cluster)
+assumes sRGB; recorded as `source_profile: "assumed-sRGB"` plus the configured
+profile filename. No profile files ship with the package; the config
+documents where to obtain e.g. ECI ISOcoated_v2_300 and the result metadata
+records profile file basename + MD5 for reproducibility.
+
+Math fallback (documented as approximate, not press-accurate):
+
+    R' = R/255, G' = G/255, B' = B/255
+    K  = 1 − max(R', G', B')
+    if K = 1: C = M = Y = 0
+    else:     C = (1−R'−K)/(1−K), M = (1−G'−K)/(1−K), Y = (1−B'−K)/(1−K)
+
+Result metadata always includes: `engine` (`math` | `imagick-icc`),
+`source_profile`, `destination_profile` (basename + md5, or null),
+`fallback` (true when auto degraded to math), `version` (algorithm version,
+starts at 1).
+
+## 8. Accumulator and output
+
+Per TRANSITION pixel with color (R,G,B) and alpha a:
+
+    w        = a / 255                  (classification weight = 1, discrete)
+    C_raw   += C(R,G,B) × w             (per unique color via histogram bins:
+    M_raw   += M(R,G,B) × w              accumulate Σw per bin, convert each
+    Y_raw   += Y(R,G,B) × w              bin color once, multiply)
+    K_raw   += K(R,G,B) × w
+
+    inkTotal = C_raw + M_raw + Y_raw + K_raw
+
+If `inkTotal > 0`: `X_percent = 100 × X_raw / inkTotal`, rounded to one
+decimal with the largest-remainder method (same technique as
+`PercentageCoverageCalculator`) so the four values sum to exactly 100.0.
+If `inkTotal = 0` (e.g. a white→transparent fade): all four percentages are
+0.0 and `ink_total` is 0 — no division, no misleading composition.
+
+`cmykJson` schema (empty transitions → `null` field / no section rendered):
+
+    {
+      "transition_coverage_percent": 31.2,   // TRANSITION px / analyzed px ×100
+      "composition_percent": {"c": 41.3, "m": 30.1, "y": 20.4, "k": 8.2},
+      "ink_total": 12345.678,                // Σ raw channels, alpha-weighted px
+      "raw_channels": {"c": ..., "m": ..., "y": ..., "k": ...},
+      "conversion": {
+        "engine": "math",
+        "source_profile": "assumed-sRGB",
+        "destination_profile": null,
+        "fallback": true,
+        "version": 1
+      }
+    }
+
+The solid list (`colorsJson`) keeps its schema; its percentages are relative to
+the solid+AA analyzed area (they still sum to 100).
+
+## 9. Configuration
+
+New `IMGCOLOR_*` constants on `imgcolor_Setup` (global config only in v1 — not
+added to `imgcolor_Profiles`, which stays a mirror of the *library* options):
+
+| Constant                        | Type   | Default | Range      |
+|---------------------------------|--------|---------|------------|
+| `IMGCOLOR_TRANS_SPAN`           | int    | 4       | 1..8       |
+| `IMGCOLOR_TRANS_NOISE_DELTAE`   | double | 1.0     | >0..20     |
+| `IMGCOLOR_TRANS_COHERENCE_MIN`  | double | 0.4     | -1..1      |
+| `IMGCOLOR_TRANS_AA_RADIUS`      | int    | 3       | 1..8       |
+| `IMGCOLOR_TRANS_MIN_SEED`       | int    | 20      | 1..289     |
+| `IMGCOLOR_TRANS_EDGE_DELTAE`    | double | 10.0    | >0..200    |
+| `IMGCOLOR_TRANS_MIN_COVERAGE`   | double | 0.005   | 0..<1      |
+| `IMGCOLOR_CMYK_ENGINE`          | enum   | auto    | auto/math/imagick |
+| `IMGCOLOR_CMYK_ICC_RGB_PROFILE` | varchar| ''      | file path  |
+| `IMGCOLOR_CMYK_ICC_CMYK_PROFILE`| varchar| ''      | file path  |
+
+Invalid values throw `InvalidArgumentException` with the field name at options
+build time, mirroring the library's `CropOptions`/`ClusterOptions` style, and
+are surfaced by `imgcolor_Setup::checkConfig()`.
+
+## 10. Components and integration
+
+New wrapper classes (bgERP conventions, no edits under `lib/`):
+
+- `imgcolor_TransitionClassifier` — stages 1–4; input a library `Raster` +
+  options array; output an object: class mask (byte string, row-major),
+  `analyzedCount`, `transitionCount`, plus a debug `renderMaskPng()` used only
+  by tests/CLI (solid=gray, AA=red, transition=blue, background=transparent).
+- `imgcolor_MaskedRaster` — implements `ImageColorAnalyzer\Contracts\Raster`;
+  wraps raster + mask; `pixels()` yields only non-TRANSITION pixels, so
+  `ColorHistogram` sees the solid+AA subset and its `total` (the percentage
+  denominator) is the solid+AA count. Used *only* when transitionCount > 0 —
+  otherwise the original raster object is passed through untouched, which
+  makes the no-transition path structurally identical to today (verified by
+  byte-comparison tests, not just asserted).
+- `imgcolor_CmykConverter` — engine selection, ICC/math conversion of a list
+  of RGB triplets, metadata block.
+- `imgcolor_CmykAccumulator` — streams TRANSITION pixels into per-color bins,
+  applies the converter, normalizes with largest-remainder, builds `cmykJson`.
+- `imgcolor_Analyzer::processSeparated($source, $options = null)` — orchestrates
+  load → crop → classify → (masked) cluster → coverage → CMYK; returns an
+  object `{json, cmykJson, croppedImage, boundingBox, wasCropped}` mirroring
+  `ProcessedImageResult` plus `cmykJson`. Existing `analyze*/process*` methods
+  and the LLM tool are unchanged.
+
+Modified: `imgcolor_Setup` (constants, version 0.4), `imgcolor_Analyses`
+(`cmykJson` field — bgERP auto-migrates added fields on setup, no manual
+migration; `createFromResult()` gains a `$cmykJson` param, default null for
+backward compatibility), `imgcolor_Demo` (uses `processSeparated()`, renders
+the CMYK section, persists `cmykJson`), `docs/integration.md`.
+
+## 11. Performance
+
+- Passes over the cropped raster: classification stage 1 (rolling 2s+1 rows of
+  packed ints), erosion (sliding counts over mask strings), flood (only over
+  CHANGING pixels, random access via `Raster::pixelAt()` for the edge cap),
+  CMYK accumulation (one streaming pass over TRANSITION pixels), clustering
+  (existing pass, unchanged). Each pass is O(N); prototype cost ≈ 0.9 s per
+  megapixel — same order as the existing crop+histogram passes.
+- Peak additional memory: 2 mask strings (1 byte/px each), one (2s+1)×W int
+  row window, the bounded Lab memo, and the flood queue (worst case O(N) ints,
+  only on gradient-dominated images). At the loader's 64 MP cap: ~128 MB masks
+  — same order as GD's own bitmap; acceptable, and typical print-logo inputs
+  are 1–16 MP.
+- ICC conversion cost is per *unique binned color* (≤ 32³ bins), not per pixel.
+
+## 12. Test strategy
+
+Framework-free CLI regression (`imgcolor/tests/cli_separation.php`, PHP 8.2+ +
+GD, no bgERP DB) generating deterministic fixtures in code, mirroring
+`cli_parity.php` style:
+
+1. Classifier fixtures (from the prototype set): solid single/multi, AA logo on
+   white/transparent, linear/shallow/steep/radial/multi-stop/diagonal/gray
+   gradients, gradient at hard edge, 1px/2px AA ramps, blurred edge, JPEG q60
+   flat + q55 ringing, sub-coverage gradient, white→transparent and
+   color→transparent fades, white-containing gradient, mixed scene, plasma
+   texture — asserting class-mask statistics (transition coverage, false
+   transition rate) within tolerances.
+2. Separation invariants: solid-only images → separated `colorsJson` byte-equal
+   to the legacy path and `cmykJson` empty; mixed image → solid list free of
+   gradient centroids, CMYK composition sums to exactly 100.0; white-only fade
+   → zero-ink case; fully transparent → both empty; 1×1 and 3×3 images (below
+   span) → all solid, no errors.
+3. Math converter unit vectors: pure R/G/B/black/white/gray → exact expected
+   CMYK; largest-remainder normalization sums.
+4. ICC engine: metadata/fallback logic tested without Imagick (auto→math with
+   `fallback: true`); conversion itself exercised only where Imagick exists
+   (skipped with a notice otherwise — recorded as a validation limitation).
+5. Web unit tests (`imgcolor_tests_Separation`) for the fileman/DB-backed flow:
+   `processSeparated()` result persisted via `imgcolor_Analyses`, `cmykJson`
+   round-trip, `renderRec()` output contains the CMYK section.
+6. Performance probe inside the CLI test (1200×800 mixed fixture, wall-clock
+   report, no hard assert).
+
+## 13. Risks and follow-ups
+
+- Thresholds are calibrated on synthetic fixtures; real-world scans may need
+  per-install tuning — all knobs are in pack config, and the debug mask PNG
+  (test/CLI only) makes disputes inspectable.
+- Percentages in the solid list change meaning for gradient-containing images
+  (denominator = solid area). Communicated in integration.md; history records
+  (`imgcolor_Analyses`) are not migrated — old records keep old semantics.
+- The LLM tool still reports the legacy un-separated view; exposing the
+  separated result to the tool is a follow-up once the JSON contract consumers
+  are known.
+- Профили (imgcolor_Profiles) do not carry the new thresholds in v1; adding
+  them (with form fields and calibration snapshot keys) is a follow-up.
+- Honoring embedded ICC source profiles requires an Imagick-first decode path —
+  out of scope; recorded in conversion metadata.

--- a/imgcolor/Analyses.class.php
+++ b/imgcolor/Analyses.class.php
@@ -51,6 +51,7 @@ class imgcolor_Analyses extends core_Manager
         $this->FLD('imageFile', 'fileman_FileType(bucket=imgcolorImages)', 'caption=Изходно изображение');
         $this->FLD('profileId', 'key(mvc=imgcolor_Profiles, select=name, allowEmpty)', 'caption=Профил');
         $this->FLD('colorsJson', 'text', 'caption=Резултат (JSON),input=none');
+        $this->FLD('cmykJson', 'text', 'caption=CMYK преливки (JSON),input=none');
         $this->FLD('calibrationJson', 'text', 'caption=Калибриране (JSON),input=none');
         $this->FLD('croppedImage', 'fileman_FileType(bucket=imgcolorImages)', 'caption=Изрязано изображение,allowEmpty');
     }
@@ -64,15 +65,17 @@ class imgcolor_Analyses extends core_Manager
      * @param string      $colorsJson JSON резултат от imgcolor_Analyzer
      * @param string|null $croppedFh  fileman handle на изрязаното изображение, ако е запазено
      * @param array|null  $calibrationValues действително използваните стойности за калибриране
+     * @param string|null $cmykJson   CMYK резултат за преливките, ако има такива
      *
      * @return int id на новия запис
      */
-    public static function createFromResult($imageFh, $profileId, $colorsJson, $croppedFh = null, $calibrationValues = null)
+    public static function createFromResult($imageFh, $profileId, $colorsJson, $croppedFh = null, $calibrationValues = null, $cmykJson = null)
     {
         $rec = new stdClass();
         $rec->imageFile = $imageFh;
         $rec->profileId = $profileId ?: null;
         $rec->colorsJson = $colorsJson;
+        $rec->cmykJson = $cmykJson;
         $rec->calibrationJson = $calibrationValues === null ? null : json_encode(imgcolor_Calibration::getValues($calibrationValues), JSON_PRESERVE_ZERO_FRACTION);
         $rec->croppedImage = $croppedFh;
 
@@ -96,6 +99,6 @@ class imgcolor_Analyses extends core_Manager
             $croppedBytes = fileman::extractStr($rec->croppedImage);
         }
 
-        return imgcolor_Demo::renderColorsHtml($rec->colorsJson, $croppedBytes);
+        return imgcolor_Demo::renderColorsHtml($rec->colorsJson, $croppedBytes, isset($rec->cmykJson) ? $rec->cmykJson : null);
     }
 }

--- a/imgcolor/Analyzer.class.php
+++ b/imgcolor/Analyzer.class.php
@@ -241,6 +241,90 @@ class imgcolor_Analyzer extends core_Mvc
 
 
     /**
+     * Праговете за класификация на преливките от глобалната конфигурация.
+     *
+     * @return array за imgcolor_TransitionClassifier::classify()
+     */
+    public static function getTransParams()
+    {
+        return array(
+            'span' => (int) imgcolor_Setup::get('TRANS_SPAN'),
+            'noiseDeltaE' => (float) imgcolor_Setup::get('TRANS_NOISE_DELTAE'),
+            'coherenceMin' => (float) imgcolor_Setup::get('TRANS_COHERENCE_MIN'),
+            'aaRadius' => (int) imgcolor_Setup::get('TRANS_AA_RADIUS'),
+            'minSeed' => (int) imgcolor_Setup::get('TRANS_MIN_SEED'),
+            'edgeDeltaE' => (float) imgcolor_Setup::get('TRANS_EDGE_DELTAE'),
+            'minCoverage' => (float) imgcolor_Setup::get('TRANS_MIN_COVERAGE'),
+        );
+    }
+
+
+    /**
+     * Конфигурацията на RGB->CMYK конверсията от глобалната конфигурация.
+     *
+     * @return array за конструктора на imgcolor_CmykConverter
+     */
+    public static function getCmykConfig()
+    {
+        return array(
+            'engine' => imgcolor_Setup::get('CMYK_ENGINE'),
+            'rgbProfile' => imgcolor_Setup::get('CMYK_ICC_RGB_PROFILE'),
+            'cmykProfile' => imgcolor_Setup::get('CMYK_ICC_CMYK_PROFILE'),
+        );
+    }
+
+
+    /**
+     * Разделен анализ: плътните цветове остават в стандартния списък
+     * (без преливките), а преливките се натрупват в CMYK акумулатор.
+     * Изображения без преливки дават байт-идентичен colors JSON с process().
+     *
+     * @param mixed $source ImageSource, stream, raw bytes или GD image
+     *
+     * @return stdClass {json, cmykJson, croppedImage, boundingBox, wasCropped}
+     */
+    public static function processSeparated($source, $options = null)
+    {
+        self::registerAutoload();
+        self::requireGd();
+
+        try {
+            $options = $options === null ? self::buildOptions() : $options;
+
+            $loader = imgcolor_Setup::get('LOADER') === 'imagick'
+                ? new \ImageColorAnalyzer\ImageLoader\ImagickImageLoader()
+                : new \ImageColorAnalyzer\ImageLoader\GdImageLoader();
+            $resolver = new \ImageColorAnalyzer\ImageLoader\SourceResolver();
+            $raster = $loader->load($resolver->resolve($source));
+
+            $sep = imgcolor_Separation::process(
+                $raster,
+                $options,
+                self::getTransParams(),
+                new imgcolor_CmykConverter(self::getCmykConfig())
+            );
+
+            $encoder = new \ImageColorAnalyzer\ImageEncoder\GdPngEncoder();
+
+            $result = new stdClass();
+            $result->json = json_encode($sep->colors, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION);
+            $result->cmykJson = $sep->cmyk === null ? null : json_encode($sep->cmyk, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION);
+            $result->croppedImage = $encoder->encode($sep->crop->raster);
+            $result->boundingBox = $sep->crop->boundingBox;
+            $result->wasCropped = $sep->crop->wasCropped;
+
+            return $result;
+        } catch (\ImageColorAnalyzer\Exception\ImageAnalyzerException $e) {
+            self::raiseError($e->getMessage());
+        } catch (InvalidArgumentException $e) {
+            self::raiseError($e->getMessage());
+        } catch (RuntimeException $e) {
+            self::raiseError($e->getMessage());
+        }
+    }
+
+
+    /**
      * @return \ImageColorAnalyzer\PublicAPI\ProcessedImageResult
      */
     public static function process($source, $options = null)

--- a/imgcolor/Analyzer.class.php
+++ b/imgcolor/Analyzer.class.php
@@ -241,13 +241,16 @@ class imgcolor_Analyzer extends core_Mvc
 
 
     /**
-     * Праговете за класификация на преливките от глобалната конфигурация.
+     * Праговете за класификация на преливките: глобалната конфигурация,
+     * при подаден профилен запис - с наслагани непразни trans* override-и.
+     *
+     * @param stdClass|null $profileRec запис на imgcolor_Profiles, или null
      *
      * @return array за imgcolor_TransitionClassifier::classify()
      */
-    public static function getTransParams()
+    public static function getTransParams($profileRec = null)
     {
-        return array(
+        $params = array(
             'span' => (int) imgcolor_Setup::get('TRANS_SPAN'),
             'noiseDeltaE' => (float) imgcolor_Setup::get('TRANS_NOISE_DELTAE'),
             'coherenceMin' => (float) imgcolor_Setup::get('TRANS_COHERENCE_MIN'),
@@ -256,6 +259,12 @@ class imgcolor_Analyzer extends core_Mvc
             'edgeDeltaE' => (float) imgcolor_Setup::get('TRANS_EDGE_DELTAE'),
             'minCoverage' => (float) imgcolor_Setup::get('TRANS_MIN_COVERAGE'),
         );
+
+        if ($profileRec !== null) {
+            $params = imgcolor_TransitionClassifier::applyOverrides($params, $profileRec);
+        }
+
+        return $params;
     }
 
 
@@ -279,11 +288,14 @@ class imgcolor_Analyzer extends core_Mvc
      * (без преливките), а преливките се натрупват в CMYK акумулатор.
      * Изображения без преливки дават байт-идентичен colors JSON с process().
      *
-     * @param mixed $source ImageSource, stream, raw bytes или GD image
+     * @param mixed      $source      ImageSource, stream, raw bytes или GD image
+     * @param mixed      $options     AnalyzerOptions или null за глобалната конфигурация
+     * @param array|null $transParams прагове за класификацията, или null за
+     *                                getTransParams() от глобалната конфигурация
      *
      * @return stdClass {json, cmykJson, croppedImage, boundingBox, wasCropped}
      */
-    public static function processSeparated($source, $options = null)
+    public static function processSeparated($source, $options = null, $transParams = null)
     {
         self::registerAutoload();
         self::requireGd();
@@ -300,7 +312,7 @@ class imgcolor_Analyzer extends core_Mvc
             $sep = imgcolor_Separation::process(
                 $raster,
                 $options,
-                self::getTransParams(),
+                $transParams === null ? self::getTransParams() : $transParams,
                 new imgcolor_CmykConverter(self::getCmykConfig())
             );
 

--- a/imgcolor/Analyzer.class.php
+++ b/imgcolor/Analyzer.class.php
@@ -369,6 +369,46 @@ class imgcolor_Analyzer extends core_Mvc
      */
     public static function analyzeFileHandle($fh, $options = null)
     {
+        $bytes = self::requireAnalyzableBytes($fh);
+
+        return self::guard(function ($a) use ($bytes, $options) {
+
+            return $a->analyzeAsJson($bytes, $options === null ? self::buildOptions() : $options);
+        });
+    }
+
+
+    /**
+     * LLM tool входна точка: разделен анализ по fileman handle - плътните
+     * цветове отделно от CMYK състава на преливките.
+     *
+     * @param string $fh - fileman манипулатор на PNG/JPEG файл
+     *
+     * @return string JSON: {"colors":[{"color","coverage_percent"},...],"cmyk":{...}|null}
+     */
+    public static function analyzeSeparatedFileHandle($fh, $options = null)
+    {
+        $bytes = self::requireAnalyzableBytes($fh);
+
+        $result = self::processSeparated($bytes, $options);
+
+        return json_encode(array(
+            'colors' => json_decode($result->json, true),
+            'cmyk' => $result->cmykJson === null ? null : json_decode($result->cmykJson, true),
+        ), JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION);
+    }
+
+
+    /**
+     * Общите проверки на LLM tool входовете: съществуващ достъпен PNG/JPEG
+     * файл с непразно съдържание.
+     *
+     * @param string $fh
+     *
+     * @return string суровите байтове на файла
+     */
+    private static function requireAnalyzableBytes($fh)
+    {
         self::registerAutoload();
 
         $fRec = fileman_Files::fetchByFh($fh);
@@ -388,10 +428,35 @@ class imgcolor_Analyzer extends core_Mvc
             self::raiseError('празно съдържание на файла');
         }
 
-        return self::guard(function ($a) use ($bytes, $options) {
+        return $bytes;
+    }
 
-            return $a->analyzeAsJson($bytes, $options === null ? self::buildOptions() : $options);
-        });
+
+    /**
+     * Self-describing tool descriptor за разделния анализ (LLM function-calling).
+     *
+     * @return array
+     */
+    public static function getSeparatedToolDefinition()
+    {
+        return array(
+            'name' => 'analyze_image_print_colors_separated',
+            'description' => 'Crop the near-white background of a PNG/JPEG stored in fileman, '
+                           . 'list the solid (spot-printable) colors with coverage percentages, and '
+                           . 'report gradients/continuous-tone areas separately as a normalized CMYK '
+                           . 'ink composition (c+m+y+k = 100) with transition area coverage. '
+                           . '"cmyk" is null when the image contains no gradients.',
+            'parameters' => array(
+                'type' => 'object',
+                'properties' => array(
+                    'fileHandle' => array(
+                        'type' => 'string',
+                        'description' => 'fileman handle (fh) of the image to analyze',
+                    ),
+                ),
+                'required' => array('fileHandle'),
+            ),
+        );
     }
 
 

--- a/imgcolor/CmykAccumulator.class.php
+++ b/imgcolor/CmykAccumulator.class.php
@@ -24,45 +24,69 @@ class imgcolor_CmykAccumulator
      * @param \ImageColorAnalyzer\Contracts\Raster $raster    изрязаният растер
      * @param stdClass                             $cls       резултат от imgcolor_TransitionClassifier::classify()
      * @param imgcolor_CmykConverter               $converter
+     * @param int                                  $bits      резолюция на квантуване, битове на канал
+     *                                                        (1..8; подава се $options->cluster->histogramBitsPerChannel,
+     *                                                        за да съвпада с резолюцията на плътното клъстеризиране)
      *
      * @return array|null null когато няма преливки; иначе payload за cmykJson
      */
-    public static function accumulate($raster, $cls, imgcolor_CmykConverter $converter)
+    public static function accumulate($raster, $cls, imgcolor_CmykConverter $converter, $bits = 5)
     {
         if (empty($cls->transitionCount)) {
 
             return null;
         }
 
-        // Групиране по 24-битов RGB ключ: тегло = сума alpha/255
+        $bits = max(1, min(8, (int) $bits));
+        $shift = 8 - $bits;
+
+        // Групиране по квантуван RGB ключ (imgcolor_ColorHistogram конвенция:
+        // <= 32^3 bins при bits=5), не по пълния 24-битов цвят - иначе фото/
+        // преливкови изображения раждат до 2^24 уникални бина и изчерпват
+        // паметта. Представителен цвят на бина = среднопретеглена стойност
+        // на попадналите пиксели; тегло за мастилото си остава сума alpha/255.
         $bins = array();
         $i = 0;
         foreach ($raster->pixels() as $px) {
             if ($cls->mask[$i++] !== imgcolor_TransitionClassifier::CLS_TRANS) {
                 continue;
             }
-            $key = ($px->r << 16) | ($px->g << 8) | $px->b;
-            $bins[$key] = (isset($bins[$key]) ? $bins[$key] : 0.0) + $px->a / 255;
+            $key = (($px->r >> $shift) << ($bits * 2))
+                | (($px->g >> $shift) << $bits)
+                | ($px->b >> $shift);
+            if (isset($bins[$key])) {
+                $bins[$key]['r'] += $px->r;
+                $bins[$key]['g'] += $px->g;
+                $bins[$key]['b'] += $px->b;
+                $bins[$key]['count']++;
+                $bins[$key]['weight'] += $px->a / 255;
+            } else {
+                $bins[$key] = array('r' => $px->r, 'g' => $px->g, 'b' => $px->b, 'count' => 1, 'weight' => $px->a / 255);
+            }
         }
 
         // Каноничен ред за детерминизъм, независим от реда на срещане
         ksort($bins);
 
         $colors = array();
-        foreach ($bins as $key => $weight) {
-            $colors[] = array(($key >> 16) & 0xFF, ($key >> 8) & 0xFF, $key & 0xFF);
+        $weights = array();
+        foreach ($bins as $bin) {
+            $colors[] = array(
+                (int) round($bin['r'] / $bin['count']),
+                (int) round($bin['g'] / $bin['count']),
+                (int) round($bin['b'] / $bin['count']),
+            );
+            $weights[] = $bin['weight'];
         }
 
         $cmyk = $converter->convert($colors);
 
         $raw = array('c' => 0.0, 'm' => 0.0, 'y' => 0.0, 'k' => 0.0);
-        $j = 0;
-        foreach ($bins as $weight) {
+        foreach ($weights as $j => $weight) {
             $raw['c'] += $cmyk[$j][0] * $weight;
             $raw['m'] += $cmyk[$j][1] * $weight;
             $raw['y'] += $cmyk[$j][2] * $weight;
             $raw['k'] += $cmyk[$j][3] * $weight;
-            $j++;
         }
 
         $inkTotal = $raw['c'] + $raw['m'] + $raw['y'] + $raw['k'];

--- a/imgcolor/CmykAccumulator.class.php
+++ b/imgcolor/CmykAccumulator.class.php
@@ -1,0 +1,132 @@
+<?php
+
+
+/**
+ * CMYK акумулатор върху преливките: групира TRANSITION пикселите по цвят,
+ * конвертира уникалните цветове (imgcolor_CmykConverter), натрупва мастилата
+ * с тегло alpha/255 и нормализира състава до точно 100.0% по метода на
+ * най-големия остатък (както PercentageCoverageCalculator на библиотеката).
+ *
+ * Без bgERP зависимост - тества се директно с
+ * `php imgcolor/tests/cli_separation.php`.
+ *
+ * @category  bgerp
+ * @package   imgcolor
+ *
+ * @license   GPL 3
+ * @since     v 0.4
+ */
+class imgcolor_CmykAccumulator
+{
+    /**
+     * Натрупва CMYK резултата за TRANSITION пикселите на растера.
+     *
+     * @param \ImageColorAnalyzer\Contracts\Raster $raster    изрязаният растер
+     * @param stdClass                             $cls       резултат от imgcolor_TransitionClassifier::classify()
+     * @param imgcolor_CmykConverter               $converter
+     *
+     * @return array|null null когато няма преливки; иначе payload за cmykJson
+     */
+    public static function accumulate($raster, $cls, imgcolor_CmykConverter $converter)
+    {
+        if (empty($cls->transitionCount)) {
+
+            return null;
+        }
+
+        // Групиране по 24-битов RGB ключ: тегло = сума alpha/255
+        $bins = array();
+        $i = 0;
+        foreach ($raster->pixels() as $px) {
+            if ($cls->mask[$i++] !== imgcolor_TransitionClassifier::CLS_TRANS) {
+                continue;
+            }
+            $key = ($px->r << 16) | ($px->g << 8) | $px->b;
+            $bins[$key] = (isset($bins[$key]) ? $bins[$key] : 0.0) + $px->a / 255;
+        }
+
+        // Каноничен ред за детерминизъм, независим от реда на срещане
+        ksort($bins);
+
+        $colors = array();
+        foreach ($bins as $key => $weight) {
+            $colors[] = array(($key >> 16) & 0xFF, ($key >> 8) & 0xFF, $key & 0xFF);
+        }
+
+        $cmyk = $converter->convert($colors);
+
+        $raw = array('c' => 0.0, 'm' => 0.0, 'y' => 0.0, 'k' => 0.0);
+        $j = 0;
+        foreach ($bins as $weight) {
+            $raw['c'] += $cmyk[$j][0] * $weight;
+            $raw['m'] += $cmyk[$j][1] * $weight;
+            $raw['y'] += $cmyk[$j][2] * $weight;
+            $raw['k'] += $cmyk[$j][3] * $weight;
+            $j++;
+        }
+
+        $inkTotal = $raw['c'] + $raw['m'] + $raw['y'] + $raw['k'];
+
+        // Изрично дефиниран нулев случай (напр. само-бяла преливка): нули,
+        // без деление - процентният състав няма смисъл без мастило.
+        $percent = array('c' => 0.0, 'm' => 0.0, 'y' => 0.0, 'k' => 0.0);
+        if ($inkTotal > 0) {
+            $percent = self::normalizePercent($raw, $inkTotal);
+        }
+
+        $rounded = array();
+        foreach ($raw as $ch => $v) {
+            $rounded[$ch] = round($v, 3);
+        }
+
+        return array(
+            'transition_coverage_percent' => round($cls->transitionCount / $cls->analyzedCount * 100, 1),
+            'composition_percent' => $percent,
+            'ink_total' => round($inkTotal, 3),
+            'raw_channels' => $rounded,
+            'conversion' => $converter->getMetadata(),
+        );
+    }
+
+
+    /**
+     * Най-голям остатък в десети от процента: четирите стойности сумират
+     * точно до 100.0 (1000 десети), без "99.9%" артефакти.
+     *
+     * @param array $raw      натрупани канали
+     * @param float $inkTotal сума на каналите (> 0)
+     *
+     * @return array
+     */
+    private static function normalizePercent(array $raw, $inkTotal)
+    {
+        $tenths = array();
+        $remainders = array();
+        $allocated = 0;
+        foreach ($raw as $ch => $v) {
+            $exact = $v / $inkTotal * 1000;
+            $floor = (int) floor($exact);
+            $tenths[$ch] = $floor;
+            $remainders[$ch] = $exact - $floor;
+            $allocated += $floor;
+        }
+
+        $order = array_keys($remainders);
+        usort($order, function ($a, $b) use ($remainders) {
+            $byRemainder = $remainders[$b] <=> $remainders[$a];
+
+            return $byRemainder !== 0 ? $byRemainder : strcmp($a, $b);
+        });
+
+        for ($i = 0; $i < 1000 - $allocated; $i++) {
+            $tenths[$order[$i]]++;
+        }
+
+        $percent = array();
+        foreach ($tenths as $ch => $t) {
+            $percent[$ch] = $t / 10.0;
+        }
+
+        return $percent;
+    }
+}

--- a/imgcolor/CmykConverter.class.php
+++ b/imgcolor/CmykConverter.class.php
@@ -1,0 +1,205 @@
+<?php
+
+
+/**
+ * RGB -> CMYK преобразувател за CMYK акумулатора на преливките.
+ *
+ * Два енджина: 'imagick-icc' (реална ICC конверсия през ext-imagick и
+ * конфигурирани профили) и 'math' (документирана апроксимативна формула,
+ * без цветови мениджмънт). 'auto' избира ICC когато е наличен, иначе math
+ * със записан fallback. Никакви ICC профили не се разпространяват с пакета -
+ * пътищата са конфигурация (IMGCOLOR_CMYK_ICC_*).
+ *
+ * Без bgERP зависимост - нарочно, за да е тестван директно с
+ * `php imgcolor/tests/cli_separation.php` (по образец на imgcolor_Calibration).
+ *
+ * @category  bgerp
+ * @package   imgcolor
+ *
+ * @license   GPL 3
+ * @since     v 0.4
+ */
+class imgcolor_CmykConverter
+{
+    /**
+     * Версия на алгоритъма за преобразуване - записва се в метаданните
+     * на резултата за възпроизводимост.
+     */
+    const VERSION = 1;
+
+
+    /**
+     * Реално избран енджин: 'math' или 'imagick-icc'
+     */
+    private $engine;
+
+
+    /**
+     * Дали 'auto' е деградирал до math (за одитируемост)
+     */
+    private $fallback = false;
+
+
+    /**
+     * Пътища до ICC профилите (при engine 'imagick-icc')
+     */
+    private $rgbProfilePath = '';
+    private $cmykProfilePath = '';
+
+
+    /**
+     * @param array $cfg array('engine' => 'auto'|'math'|'imagick',
+     *                         'rgbProfile' => string, 'cmykProfile' => string)
+     *
+     * @throws InvalidArgumentException при непознат енджин или engine=imagick
+     *                                  без налични предпоставки
+     */
+    public function __construct(array $cfg)
+    {
+        $engine = isset($cfg['engine']) ? (string) $cfg['engine'] : 'auto';
+        if (!in_array($engine, array('auto', 'math', 'imagick'), true)) {
+            throw new InvalidArgumentException("CMYK engine must be one of auto|math|imagick: {$engine}");
+        }
+
+        $rgb = isset($cfg['rgbProfile']) ? (string) $cfg['rgbProfile'] : '';
+        $cmyk = isset($cfg['cmykProfile']) ? (string) $cfg['cmykProfile'] : '';
+
+        $iccReady = extension_loaded('imagick')
+            && $rgb !== '' && is_readable($rgb)
+            && $cmyk !== '' && is_readable($cmyk);
+
+        if ($engine === 'imagick') {
+            if (!$iccReady) {
+                throw new InvalidArgumentException('CMYK engine "imagick" requires ext-imagick and readable RGB/CMYK ICC profile files');
+            }
+            $this->engine = 'imagick-icc';
+        } elseif ($engine === 'math') {
+            $this->engine = 'math';
+        } else {
+            $this->engine = $iccReady ? 'imagick-icc' : 'math';
+            $this->fallback = !$iccReady;
+        }
+
+        if ($this->engine === 'imagick-icc') {
+            $this->rgbProfilePath = $rgb;
+            $this->cmykProfilePath = $cmyk;
+        }
+    }
+
+
+    /**
+     * Преобразува списък RGB цветове към CMYK дялове 0..1, в същия ред.
+     *
+     * @param array $colors list of array(r, g, b), канали 0..255
+     *
+     * @return array list of array(c, m, y, k), дялове 0..1
+     */
+    public function convert(array $colors)
+    {
+        if (!count($colors)) {
+
+            return array();
+        }
+
+        return $this->engine === 'imagick-icc' ? $this->convertIcc($colors) : $this->convertMath($colors);
+    }
+
+
+    /**
+     * Метаданни за одитируемост на резултата (записват се в cmykJson).
+     *
+     * @return array
+     */
+    public function getMetadata()
+    {
+        $source = 'assumed-sRGB';
+        $destination = null;
+        if ($this->engine === 'imagick-icc') {
+            $source = 'assumed-sRGB:' . basename($this->rgbProfilePath) . ':' . md5_file($this->rgbProfilePath);
+            $destination = basename($this->cmykProfilePath) . ':' . md5_file($this->cmykProfilePath);
+        }
+
+        return array(
+            'engine' => $this->engine,
+            'source_profile' => $source,
+            'destination_profile' => $destination,
+            'fallback' => $this->fallback,
+            'version' => self::VERSION,
+        );
+    }
+
+
+    /**
+     * Апроксимативна математическа конверсия (не е точна за печатна преса):
+     *   K = 1 - max(R', G', B'); C = (1-R'-K)/(1-K) и т.н.
+     *
+     * @param array $colors
+     *
+     * @return array
+     */
+    private function convertMath(array $colors)
+    {
+        $result = array();
+        foreach ($colors as $rgb) {
+            $r = $rgb[0] / 255;
+            $g = $rgb[1] / 255;
+            $b = $rgb[2] / 255;
+            $k = 1.0 - max($r, $g, $b);
+            if ($k > 1.0 - 1e-9) {
+                $result[] = array(0.0, 0.0, 0.0, 1.0);
+            } else {
+                $d = 1.0 - $k;
+                $result[] = array((1.0 - $r - $k) / $d, (1.0 - $g - $k) / $d, (1.0 - $b - $k) / $d, $k);
+            }
+        }
+
+        return $result;
+    }
+
+
+    /**
+     * ICC конверсия през Imagick: уникалните цветове се нареждат в канава
+     * 1px висока, тагват се с конфигурирания RGB профил и се конвертират
+     * към конфигурирания CMYK профил (LCMS, rendering intent по подразбиране
+     * на ImageMagick). Цената е по един пиксел на уникален цвят.
+     *
+     * @param array $colors
+     *
+     * @throws RuntimeException при грешка на Imagick
+     *
+     * @return array
+     */
+    private function convertIcc(array $colors)
+    {
+        $n = count($colors);
+        $bytes = '';
+        foreach ($colors as $rgb) {
+            $bytes .= chr($rgb[0]) . chr($rgb[1]) . chr($rgb[2]);
+        }
+
+        try {
+            $img = new Imagick();
+            $img->newImage($n, 1, new ImagickPixel('black'));
+            $img->setImageType(Imagick::IMGTYPE_TRUECOLOR);
+            $img->importImagePixels(0, 0, $n, 1, 'RGB', Imagick::PIXEL_CHAR, $bytes);
+            $img->profileImage('icc', file_get_contents($this->rgbProfilePath));
+            $img->profileImage('icc', file_get_contents($this->cmykProfilePath));
+            $out = $img->exportImagePixels(0, 0, $n, 1, 'CMYK', Imagick::PIXEL_CHAR);
+            $img->clear();
+        } catch (ImagickException $e) {
+            throw new RuntimeException('ICC CMYK conversion failed: ' . $e->getMessage(), 0, $e);
+        }
+
+        $result = array();
+        for ($i = 0; $i < $n; $i++) {
+            $result[] = array(
+                $out[4 * $i] / 255,
+                $out[4 * $i + 1] / 255,
+                $out[4 * $i + 2] / 255,
+                $out[4 * $i + 3] / 255,
+            );
+        }
+
+        return $result;
+    }
+}

--- a/imgcolor/Demo.class.php
+++ b/imgcolor/Demo.class.php
@@ -163,7 +163,7 @@ class imgcolor_Demo extends core_Manager
                     }
 
                     $bytes = fileman::extractStr($form->rec->imageFile);
-                    $result = imgcolor_Analyzer::processSeparated($bytes, $options);
+                    $result = imgcolor_Analyzer::processSeparated($bytes, $options, imgcolor_Analyzer::getTransParams($profileRec));
                     $resultHtml = self::renderResult($result);
 
                     self::persistResult($form->rec->imageFile, $form->rec->profileId, $result, $calibrationValues);

--- a/imgcolor/Demo.class.php
+++ b/imgcolor/Demo.class.php
@@ -163,7 +163,7 @@ class imgcolor_Demo extends core_Manager
                     }
 
                     $bytes = fileman::extractStr($form->rec->imageFile);
-                    $result = imgcolor_Analyzer::process($bytes, $options);
+                    $result = imgcolor_Analyzer::processSeparated($bytes, $options);
                     $resultHtml = self::renderResult($result);
 
                     self::persistResult($form->rec->imageFile, $form->rec->profileId, $result, $calibrationValues);
@@ -239,7 +239,7 @@ class imgcolor_Demo extends core_Manager
 
         try {
             $calibrationValues = imgcolor_Calibration::getDefaultValues();
-            $result = imgcolor_Analyzer::process(fileman::extractStr($fh), imgcolor_Calibration::buildOptions($calibrationValues));
+            $result = imgcolor_Analyzer::processSeparated(fileman::extractStr($fh), imgcolor_Calibration::buildOptions($calibrationValues));
             self::persistResult($fh, null, $result, $calibrationValues);
         } catch (core_exception_Expect $e) {
 
@@ -297,10 +297,11 @@ class imgcolor_Demo extends core_Manager
      *
      * @param string      $colorsJson        JSON резултат ([{color, coverage_percent}, ...])
      * @param string|null $croppedImageBytes суровите байтове на изрязаното PNG, ако има
+     * @param string|null $cmykJson          CMYK резултат за преливките, ако има такива
      *
      * @return string
      */
-    public static function renderColorsHtml($colorsJson, $croppedImageBytes = null)
+    public static function renderColorsHtml($colorsJson, $croppedImageBytes = null, $cmykJson = null)
     {
         $colors = json_decode($colorsJson, true);
         if (!is_array($colors)) {
@@ -325,14 +326,66 @@ class imgcolor_Demo extends core_Manager
         return "<div style='display:flex;gap:24px;flex-wrap:wrap'>"
             . "<div>{$imgTag}</div>"
             . "<div>{$swatches}</div>"
+            . self::renderCmykHtml($cmykJson)
             . '</div>';
     }
 
 
     /**
-     * Рендира резултата от imgcolor_Analyzer::process() - живия преглед.
+     * Рендира CMYK блока за преливките: покритие, състав на мастилата
+     * (сумиращ точно 100%) и използвания енджин за конверсия.
      *
-     * @param \ImageColorAnalyzer\PublicAPI\ProcessedImageResult $result
+     * @param string|null $cmykJson
+     *
+     * @return string празен низ, когато няма преливки
+     */
+    public static function renderCmykHtml($cmykJson)
+    {
+        if (!is_string($cmykJson) || $cmykJson === '') {
+
+            return '';
+        }
+
+        $cmyk = json_decode($cmykJson, true);
+        if (!is_array($cmyk) || !isset($cmyk['composition_percent'])) {
+
+            return '';
+        }
+
+        $channels = array(
+            'c' => array('Cyan', '#00AEEF'),
+            'm' => array('Magenta', '#EC008C'),
+            'y' => array('Yellow', '#FFF200'),
+            'k' => array('Black', '#231F20'),
+        );
+
+        $bars = '';
+        foreach ($channels as $ch => $def) {
+            $pct = isset($cmyk['composition_percent'][$ch]) ? (float) $cmyk['composition_percent'][$ch] : 0.0;
+            $width = (int) round($pct * 2);
+            $bars .= "<div style='display:flex;align-items:center;gap:8px;margin:2px 0'>"
+                . "<span style='display:inline-block;width:64px'>{$def[0]}</span>"
+                . "<span style='display:inline-block;width:{$width}px;height:14px;background:{$def[1]};border:1px solid #999'></span>"
+                . "<code>{$pct}%</code></div>";
+        }
+
+        $coverage = isset($cmyk['transition_coverage_percent']) ? (float) $cmyk['transition_coverage_percent'] : 0.0;
+        $engine = isset($cmyk['conversion']['engine']) ? htmlspecialchars((string) $cmyk['conversion']['engine'], ENT_QUOTES, 'UTF-8') : '?';
+        $note = tr('Преливки (CMYK)') . ": {$coverage}% " . tr('от анализираната площ');
+        if (isset($cmyk['ink_total']) && (float) $cmyk['ink_total'] == 0.0) {
+            $note .= ' - ' . tr('без мастилено съдържание');
+        }
+
+        return "<div><b>{$note}</b>{$bars}"
+            . "<div style='color:#777;font-size:0.9em'>" . tr('Конверсия') . ": <code>{$engine}</code></div></div>";
+    }
+
+
+    /**
+     * Рендира резултата от imgcolor_Analyzer::processSeparated() (или
+     * legacy process()) - живия преглед.
+     *
+     * @param stdClass|\ImageColorAnalyzer\PublicAPI\ProcessedImageResult $result
      *
      * @return string
      */
@@ -343,7 +396,7 @@ class imgcolor_Demo extends core_Manager
             $croppedBytes = $result->croppedImage->bytes;
         }
 
-        return self::renderColorsHtml($result->json, $croppedBytes);
+        return self::renderColorsHtml($result->json, $croppedBytes, self::extractCmykJson($result));
     }
 
 
@@ -351,10 +404,10 @@ class imgcolor_Demo extends core_Manager
      * Записва завършен анализ в imgcolor_Analyses за бъдещо преизползване/справка.
      * Публичен метод, за да е тестваем директно (виж imgcolor_tests_Analyses).
      *
-     * @param string                                            $imageFh   fileman handle на изходния файл
-     * @param int|null                                          $profileId избран профил, или празно за глобална конфигурация
-     * @param \ImageColorAnalyzer\PublicAPI\ProcessedImageResult $result
-     * @param array|null                                        $calibrationValues действително използваните стойности
+     * @param string                                                      $imageFh   fileman handle на изходния файл
+     * @param int|null                                                    $profileId избран профил, или празно за глобална конфигурация
+     * @param stdClass|\ImageColorAnalyzer\PublicAPI\ProcessedImageResult $result
+     * @param array|null                                                  $calibrationValues действително използваните стойности
      */
     public static function persistResult($imageFh, $profileId, $result, $calibrationValues = null)
     {
@@ -363,7 +416,21 @@ class imgcolor_Demo extends core_Manager
             $croppedFh = fileman::absorbStr($result->croppedImage->bytes, 'imgcolorImages', 'cropped.png');
         }
 
-        imgcolor_Analyses::createFromResult($imageFh, $profileId, $result->json, $croppedFh, $calibrationValues);
+        imgcolor_Analyses::createFromResult($imageFh, $profileId, $result->json, $croppedFh, $calibrationValues, self::extractCmykJson($result));
+    }
+
+
+    /**
+     * CMYK JSON от резултат на processSeparated(); legacy process()
+     * резултатите нямат такова поле.
+     *
+     * @param object $result
+     *
+     * @return string|null
+     */
+    private static function extractCmykJson($result)
+    {
+        return (isset($result->cmykJson) && is_string($result->cmykJson)) ? $result->cmykJson : null;
     }
 
 

--- a/imgcolor/MaskedRaster.class.php
+++ b/imgcolor/MaskedRaster.class.php
@@ -1,0 +1,86 @@
+<?php
+
+
+/**
+ * Raster декоратор, който скрива класифицираните като преливка пиксели от
+ * pixels() итерацията, за да ги изключи от съществуващото клъстеризиране
+ * (ColorHistogram консумира само pixels()). Използва се единствено когато
+ * има намерени преливки - иначе оригиналният растер се подава директно и
+ * пътят на плътните цветове е байт-идентичен с досегашния.
+ *
+ * @category  bgerp
+ * @package   imgcolor
+ *
+ * @license   GPL 3
+ * @since     v 0.4
+ */
+class imgcolor_MaskedRaster implements \ImageColorAnalyzer\Contracts\Raster
+{
+    private $raster;
+    private $mask;
+    private $skipByte;
+
+
+    /**
+     * @param \ImageColorAnalyzer\Contracts\Raster $raster
+     * @param string                               $mask     байтова маска W*H (imgcolor_TransitionClassifier)
+     * @param string                               $skipByte кой клас да се скрие
+     */
+    public function __construct(\ImageColorAnalyzer\Contracts\Raster $raster, $mask, $skipByte = imgcolor_TransitionClassifier::CLS_TRANS)
+    {
+        if (strlen($mask) !== $raster->width() * $raster->height()) {
+            throw new InvalidArgumentException('Mask length must equal raster width*height');
+        }
+        $this->raster = $raster;
+        $this->mask = $mask;
+        $this->skipByte = $skipByte;
+    }
+
+
+    public function width(): int
+    {
+        return $this->raster->width();
+    }
+
+
+    public function height(): int
+    {
+        return $this->raster->height();
+    }
+
+
+    public function hasAlpha(): bool
+    {
+        return $this->raster->hasAlpha();
+    }
+
+
+    /**
+     * Достъп по координати - без маскиране; маската важи само за pixels().
+     */
+    public function pixelAt(int $x, int $y): \ImageColorAnalyzer\Contracts\ColorRGBA
+    {
+        return $this->raster->pixelAt($x, $y);
+    }
+
+
+    /**
+     * @return iterable<\ImageColorAnalyzer\Contracts\ColorRGBA>
+     */
+    public function pixels(): iterable
+    {
+        $i = 0;
+        foreach ($this->raster->pixels() as $pixel) {
+            if ($this->mask[$i++] === $this->skipByte) {
+                continue;
+            }
+            yield $pixel;
+        }
+    }
+
+
+    public function crop(\ImageColorAnalyzer\Contracts\BoundingBox $box): \ImageColorAnalyzer\Contracts\Raster
+    {
+        throw new \ImageColorAnalyzer\Exception\NotImplementedException('imgcolor_MaskedRaster does not support cropping');
+    }
+}

--- a/imgcolor/Profiles.class.php
+++ b/imgcolor/Profiles.class.php
@@ -65,6 +65,16 @@ class imgcolor_Profiles extends core_Manager
         $this->FLD('clusterSeed', 'int', 'caption=Клъстеризиране->Seed (детерминизъм),mandatory');
         $this->FLD('clusterAlphaThreshold', 'int', 'caption=Клъстеризиране->Праг прозрачност (0-255),mandatory');
 
+        // Опционални override-и на праговете за преливки (CMYK отделяне);
+        // празно поле означава "използвай глобалната IMGCOLOR_TRANS_* стойност".
+        $this->FLD('transSpan', 'int', 'caption=Преливки->Обхват на пробите (px),allowEmpty');
+        $this->FLD('transNoiseDeltaE', 'double', 'caption=Преливки->Шумов праг (deltaE),allowEmpty');
+        $this->FLD('transCoherenceMin', 'double', 'caption=Преливки->Мин. кохерентност (косинус),allowEmpty');
+        $this->FLD('transAaRadius', 'int', 'caption=Преливки->Радиус на ерозия (px),allowEmpty');
+        $this->FLD('transMinSeed', 'int', 'caption=Преливки->Мин. пиксели за seed,allowEmpty');
+        $this->FLD('transEdgeDeltaE', 'double', 'caption=Преливки->Праг твърд ръб (deltaE),allowEmpty');
+        $this->FLD('transMinCoverage', 'double', 'caption=Преливки->Мин. покритие (дял),allowEmpty');
+
         $this->FLD('notes', 'text(rows=4)', 'caption=Бележки');
 
         $this->setDbUnique('sysId');
@@ -105,6 +115,9 @@ class imgcolor_Profiles extends core_Manager
     {
         try {
             imgcolor_Calibration::buildOptions(imgcolor_Calibration::getValues($rec));
+            imgcolor_TransitionClassifier::normalizeParams(
+                imgcolor_TransitionClassifier::applyOverrides(imgcolor_TransitionClassifier::$defaults, $rec)
+            );
         } catch (InvalidArgumentException $e) {
             throw new core_exception_Expect('imgcolor: ' . $e->getMessage(), 'Несъответствие');
         }

--- a/imgcolor/Separation.class.php
+++ b/imgcolor/Separation.class.php
@@ -56,7 +56,12 @@ class imgcolor_Separation
 
         $result = new stdClass();
         $result->colors = $colors;
-        $result->cmyk = imgcolor_CmykAccumulator::accumulate($crop->raster, $classification, $converter);
+        $result->cmyk = imgcolor_CmykAccumulator::accumulate(
+            $crop->raster,
+            $classification,
+            $converter,
+            $options->cluster->histogramBitsPerChannel
+        );
         if ($result->cmyk !== null) {
             // Действително използваните (нормализирани) прагове - за
             // одитируемост, както conversion блока на конвертора.

--- a/imgcolor/Separation.class.php
+++ b/imgcolor/Separation.class.php
@@ -57,6 +57,11 @@ class imgcolor_Separation
         $result = new stdClass();
         $result->colors = $colors;
         $result->cmyk = imgcolor_CmykAccumulator::accumulate($crop->raster, $classification, $converter);
+        if ($result->cmyk !== null) {
+            // Действително използваните (нормализирани) прагове - за
+            // одитируемост, както conversion блока на конвертора.
+            $result->cmyk['classifier'] = $classification->params;
+        }
         $result->crop = $crop;
         $result->classification = $classification;
 

--- a/imgcolor/Separation.class.php
+++ b/imgcolor/Separation.class.php
@@ -1,0 +1,65 @@
+<?php
+
+
+/**
+ * bgERP-независим оркестратор на разделния анализ: изрязване (библиотечен
+ * cropper) -> класификация на преливките -> клъстеризиране на плътните
+ * цветове (непроменен библиотечен път; при липса на преливки оригиналният
+ * растер се подава директно за байт-идентичен резултат) -> CMYK акумулация.
+ *
+ * Тества се директно с `php imgcolor/tests/cli_separation.php`.
+ *
+ * @category  bgerp
+ * @package   imgcolor
+ *
+ * @license   GPL 3
+ * @since     v 0.4
+ */
+class imgcolor_Separation
+{
+    /**
+     * @param \ImageColorAnalyzer\Contracts\Raster        $raster      зареден (неизрязан) растер
+     * @param \ImageColorAnalyzer\Options\AnalyzerOptions $options
+     * @param array                                       $transParams прагове за imgcolor_TransitionClassifier
+     * @param imgcolor_CmykConverter                      $converter
+     *
+     * @return stdClass {colors, cmyk, crop, classification}
+     */
+    public static function process($raster, $options, array $transParams, imgcolor_CmykConverter $converter)
+    {
+        $libConverter = new \ImageColorAnalyzer\Color\ColorConverter();
+
+        $cropper = new \ImageColorAnalyzer\WhiteBackgroundCropper\WhiteBackgroundCropper($libConverter);
+        $crop = $cropper->crop($raster, $options->crop);
+
+        // BACKGROUND дефиницията следва прага на клъстеризирането, за да
+        // съвпада с досегашното изключване на прозрачни пиксели.
+        $transParams['alphaThreshold'] = $options->cluster->alphaThreshold;
+        $classification = imgcolor_TransitionClassifier::classify($crop->raster, $transParams);
+
+        $clusterInput = $classification->transitionCount > 0
+            ? new imgcolor_MaskedRaster($crop->raster, $classification->mask)
+            : $crop->raster;
+
+        $clusterer = new \ImageColorAnalyzer\ColorClusterer\KMeansClusterer(
+            $libConverter,
+            new \ImageColorAnalyzer\ColorClusterer\ColorHistogram(),
+            new \ImageColorAnalyzer\ColorClusterer\KSelector($libConverter)
+        );
+        $clusters = $clusterer->cluster($clusterInput, $options->cluster);
+
+        $colors = array();
+        $coverage = new \ImageColorAnalyzer\CoverageCalculator\PercentageCoverageCalculator();
+        foreach ($coverage->calculate($clusters) as $item) {
+            $colors[] = $item->toArray();
+        }
+
+        $result = new stdClass();
+        $result->colors = $colors;
+        $result->cmyk = imgcolor_CmykAccumulator::accumulate($crop->raster, $classification, $converter);
+        $result->crop = $crop;
+        $result->classification = $classification;
+
+        return $result;
+    }
+}

--- a/imgcolor/Setup.class.php
+++ b/imgcolor/Setup.class.php
@@ -29,6 +29,30 @@ defIfNot('IMGCOLOR_CLUSTER_ALPHA_THRESHOLD', 8);
 
 
 /**
+ * Класификация на преливките (CMYK отделяне) - прагове на
+ * imgcolor_TransitionClassifier. Единици и ефект - виж
+ * docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.md §4.
+ */
+defIfNot('IMGCOLOR_TRANS_SPAN', 4);
+defIfNot('IMGCOLOR_TRANS_NOISE_DELTAE', 1.0);
+defIfNot('IMGCOLOR_TRANS_COHERENCE_MIN', 0.4);
+defIfNot('IMGCOLOR_TRANS_AA_RADIUS', 3);
+defIfNot('IMGCOLOR_TRANS_MIN_SEED', 20);
+defIfNot('IMGCOLOR_TRANS_EDGE_DELTAE', 10.0);
+defIfNot('IMGCOLOR_TRANS_MIN_COVERAGE', 0.005);
+
+
+/**
+ * RGB -> CMYK конверсия за акумулатора на преливките. Без включени ICC
+ * профили в пакета - при 'auto' без конфигурирани профили се ползва
+ * математическата апроксимация (записва се в резултата като fallback).
+ */
+defIfNot('IMGCOLOR_CMYK_ENGINE', 'auto');
+defIfNot('IMGCOLOR_CMYK_ICC_RGB_PROFILE', '');
+defIfNot('IMGCOLOR_CMYK_ICC_CMYK_PROFILE', '');
+
+
+/**
  * Пакет за анализ на основните цветове за печат в изображение (PNG/JPEG)
  *
  * @category  bgerp
@@ -42,7 +66,7 @@ class imgcolor_Setup extends core_ProtoSetup
     /**
      * Версия на пакета
      */
-    public $version = '0.3';
+    public $version = '0.4';
 
 
     /**
@@ -116,6 +140,18 @@ class imgcolor_Setup extends core_ProtoSetup
         'IMGCOLOR_CLUSTER_MIN_COVERAGE' => array('double', 'caption=Клъстеризиране->Мин. покривност на клъстер'),
         'IMGCOLOR_CLUSTER_SEED' => array('int', 'caption=Клъстеризиране->Seed (детерминизъм)'),
         'IMGCOLOR_CLUSTER_ALPHA_THRESHOLD' => array('int', 'caption=Клъстеризиране->Праг прозрачност (0-255)'),
+
+        'IMGCOLOR_TRANS_SPAN' => array('int', 'caption=Преливки->Обхват на пробите (px)'),
+        'IMGCOLOR_TRANS_NOISE_DELTAE' => array('double', 'caption=Преливки->Шумов праг (deltaE)'),
+        'IMGCOLOR_TRANS_COHERENCE_MIN' => array('double', 'caption=Преливки->Мин. кохерентност (косинус)'),
+        'IMGCOLOR_TRANS_AA_RADIUS' => array('int', 'caption=Преливки->Радиус на ерозия (px)'),
+        'IMGCOLOR_TRANS_MIN_SEED' => array('int', 'caption=Преливки->Мин. пиксели за seed'),
+        'IMGCOLOR_TRANS_EDGE_DELTAE' => array('double', 'caption=Преливки->Праг твърд ръб (deltaE)'),
+        'IMGCOLOR_TRANS_MIN_COVERAGE' => array('double', 'caption=Преливки->Мин. покритие (дял)'),
+
+        'IMGCOLOR_CMYK_ENGINE' => array('enum(auto=Автоматично,math=Математическа формула,imagick=Imagick + ICC)', 'caption=CMYK->Енджин'),
+        'IMGCOLOR_CMYK_ICC_RGB_PROFILE' => array('varchar', 'caption=CMYK->Път до RGB ICC профил'),
+        'IMGCOLOR_CMYK_ICC_CMYK_PROFILE' => array('varchar', 'caption=CMYK->Път до CMYK ICC профил'),
     );
 
 
@@ -153,6 +189,8 @@ class imgcolor_Setup extends core_ProtoSetup
 
         try {
             imgcolor_Analyzer::buildOptions();
+            imgcolor_TransitionClassifier::normalizeParams(imgcolor_Analyzer::getTransParams());
+            new imgcolor_CmykConverter(imgcolor_Analyzer::getCmykConfig());
         } catch (InvalidArgumentException $e) {
 
             return 'Некоректна imgcolor конфигурация: ' . $e->getMessage();

--- a/imgcolor/TransitionClassifier.class.php
+++ b/imgcolor/TransitionClassifier.class.php
@@ -1,0 +1,27 @@
+<?php
+
+
+/**
+ * Тристепенна пространствена класификация на пикселите за отделяне на
+ * преливки (CMYK) от плътни цветове. Виж
+ * docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.md.
+ *
+ * Без bgERP зависимост - тества се директно с
+ * `php imgcolor/tests/cli_separation.php`.
+ *
+ * @category  bgerp
+ * @package   imgcolor
+ *
+ * @license   GPL 3
+ * @since     v 0.4
+ */
+class imgcolor_TransitionClassifier
+{
+    /**
+     * Класове пиксели - байтови стойности в маската (ред по редове, W*H байта)
+     */
+    const CLS_BG = "\x00";
+    const CLS_SOLID = "\x01";
+    const CLS_AA = "\x02";
+    const CLS_TRANS = "\x03";
+}

--- a/imgcolor/TransitionClassifier.class.php
+++ b/imgcolor/TransitionClassifier.class.php
@@ -42,10 +42,12 @@ class imgcolor_TransitionClassifier
 
 
     /**
-     * Временен маркер по време на реконструкцията: AA пиксел, вече отхвърлен
-     * като твърд ръб - да не се тества повторно от друг съсед.
+     * Временни маркери по време на реконструкцията/дилатацията: пиксел,
+     * вече отхвърлен като твърд ръб - да не се тества повторно от друг
+     * съсед. Възстановяват се към AA/SOLID в края.
      */
     const CLS_BLOCKED = "\x04";
+    const CLS_BLOCKED_SOLID = "\x05";
 
 
     /**
@@ -312,9 +314,49 @@ class imgcolor_TransitionClassifier
                 }
             }
         }
-        if ($head > 0) {
-            $mask = strtr($mask, array(self::CLS_BLOCKED => self::CLS_AA));
+        // Етап 3.5: ограничена дилатация - кохерентният тест не достига
+        // последните span пиксела на всяка преливка (едната му проба излиза
+        // от region-а), затова преливката поглъща съседните не-ръбови
+        // пиксели до дълбочина span. При липса на преливки е no-op, така
+        // че пътят на плътните изображения остава байт-идентичен.
+        $frontier = $queue;
+        for ($depth = 0; $depth < $span && count($frontier); $depth++) {
+            $next = array();
+            foreach ($frontier as $i) {
+                $cy = intdiv($i, $w);
+                $cx = $i - $cy * $w;
+                for ($dy = -1; $dy <= 1; $dy++) {
+                    $ny = $cy + $dy;
+                    if ($ny < 0 || $ny >= $h) {
+                        continue;
+                    }
+                    for ($dx = -1; $dx <= 1; $dx++) {
+                        if ($dx === 0 && $dy === 0) {
+                            continue;
+                        }
+                        $nx = $cx + $dx;
+                        if ($nx < 0 || $nx >= $w) {
+                            continue;
+                        }
+                        $j = $ny * $w + $nx;
+                        $b = $mask[$j];
+                        if ($b !== self::CLS_AA && $b !== self::CLS_SOLID) {
+                            continue;
+                        }
+                        if (self::isHardEdge($data, $nx, $ny, $w, $h, $alphaThr, $edgeCap)) {
+                            $mask[$j] = $b === self::CLS_SOLID ? self::CLS_BLOCKED_SOLID : self::CLS_BLOCKED;
+                            continue;
+                        }
+                        $mask[$j] = self::CLS_TRANS;
+                        $next[] = $j;
+                        $transitionCount++;
+                    }
+                }
+            }
+            $frontier = $next;
         }
+
+        $mask = strtr($mask, array(self::CLS_BLOCKED => self::CLS_AA, self::CLS_BLOCKED_SOLID => self::CLS_SOLID));
 
         // Етап 4: пазач по минимално покритие
         if ($analyzed === 0 || $transitionCount / $analyzed < $p['minCoverage']) {

--- a/imgcolor/TransitionClassifier.class.php
+++ b/imgcolor/TransitionClassifier.class.php
@@ -3,8 +3,23 @@
 
 /**
  * Тристепенна пространствена класификация на пикселите за отделяне на
- * преливки (CMYK) от плътни цветове. Виж
- * docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.md.
+ * преливки (CMYK) от плътни цветове.
+ *
+ * Алгоритъм (виж docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.md §4):
+ *  1. "Кохерентен дрейф": за всяка ос пикселът се сравнява с двете си
+ *     проби на разстояние span в CIELAB+alpha; той е CHANGING само ако
+ *     двете полу-разлики сочат в една посока (dot cosine >= coherenceMin)
+ *     и средната им дължина е >= noiseDeltaE. Градиентите акумулират
+ *     сигнал линейно със span, а JPEG шум/ringing са некохерентни и отпадат.
+ *  2. Ерозия: seed е CHANGING пиксел, чийто (2r+1)^2 прозорец не съдържа
+ *     SOLID и има поне minSeed CHANGING - тесните AA/blur ленти изчезват.
+ *  3. Реконструкция: 8-свързан flood от seeds по CHANGING, блокиран при
+ *     твърд ръб (макс. съседна разлика > edgeDeltaE) - не изтича по контури.
+ *  4. Пазач: под minCoverage дял всичко се връща към AA (складира се при
+ *     плътните цветове), за да не регистрират шумови петна CMYK съдържание.
+ *
+ * Останалите CHANGING пиксели са клас AA/EDGE и остават в пътя на плътните
+ * цветове, където съществуващото сливане по deltaE ги поглъща - както днес.
  *
  * Без bgERP зависимост - тества се директно с
  * `php imgcolor/tests/cli_separation.php`.
@@ -24,4 +39,481 @@ class imgcolor_TransitionClassifier
     const CLS_SOLID = "\x01";
     const CLS_AA = "\x02";
     const CLS_TRANS = "\x03";
+
+
+    /**
+     * Временен маркер по време на реконструкцията: AA пиксел, вече отхвърлен
+     * като твърд ръб - да не се тества повторно от друг съсед.
+     */
+    const CLS_BLOCKED = "\x04";
+
+
+    /**
+     * Горна граница на Lab кеша по 24-битов RGB ключ (по образец на
+     * WhiteBackgroundCropper::MEMO_CAP) - отвъд нея се смята без кеш.
+     */
+    const LAB_MEMO_CAP = 65536;
+
+
+    /**
+     * Прагове по подразбиране - калибрирани върху фикстурите на прототипа
+     * (виж спецификацията, таблицата в §4).
+     */
+    public static $defaults = array(
+        'span' => 4,
+        'noiseDeltaE' => 1.0,
+        'coherenceMin' => 0.4,
+        'aaRadius' => 3,
+        'minSeed' => 20,
+        'edgeDeltaE' => 10.0,
+        'minCoverage' => 0.005,
+        'alphaThreshold' => 8,
+    );
+
+
+    /**
+     * @var \ImageColorAnalyzer\Color\ColorConverter|null
+     */
+    private static $converter;
+
+
+    /**
+     * @var array rgb24 => array(L, a, b)
+     */
+    private static $labMemo = array();
+
+
+    /**
+     * Валидира и попълва праговете; непознатите ключове се игнорират.
+     *
+     * @param array $params
+     *
+     * @throws InvalidArgumentException с името на полето при стойност извън диапазона
+     *
+     * @return array
+     */
+    public static function normalizeParams(array $params)
+    {
+        $p = array_merge(self::$defaults, array_intersect_key($params, self::$defaults));
+
+        $p['span'] = (int) $p['span'];
+        if ($p['span'] < 1 || $p['span'] > 8) {
+            throw new InvalidArgumentException('Transition span must be in the range 1..8');
+        }
+
+        $p['noiseDeltaE'] = (float) $p['noiseDeltaE'];
+        if ($p['noiseDeltaE'] <= 0 || $p['noiseDeltaE'] > 20) {
+            throw new InvalidArgumentException('Transition noiseDeltaE must be in the range (0..20]');
+        }
+
+        $p['coherenceMin'] = (float) $p['coherenceMin'];
+        if ($p['coherenceMin'] < -1 || $p['coherenceMin'] > 1) {
+            throw new InvalidArgumentException('Transition coherenceMin must be in the range -1..1');
+        }
+
+        $p['aaRadius'] = (int) $p['aaRadius'];
+        if ($p['aaRadius'] < 1 || $p['aaRadius'] > 8) {
+            throw new InvalidArgumentException('Transition aaRadius must be in the range 1..8');
+        }
+
+        $p['minSeed'] = (int) $p['minSeed'];
+        if ($p['minSeed'] < 1 || $p['minSeed'] > 289) {
+            throw new InvalidArgumentException('Transition minSeed must be in the range 1..289');
+        }
+
+        $p['edgeDeltaE'] = (float) $p['edgeDeltaE'];
+        if ($p['edgeDeltaE'] <= 0 || $p['edgeDeltaE'] > 200) {
+            throw new InvalidArgumentException('Transition edgeDeltaE must be in the range (0..200]');
+        }
+
+        $p['minCoverage'] = (float) $p['minCoverage'];
+        if ($p['minCoverage'] < 0 || $p['minCoverage'] >= 1) {
+            throw new InvalidArgumentException('Transition minCoverage must be in the range 0..<1');
+        }
+
+        $p['alphaThreshold'] = (int) $p['alphaThreshold'];
+        if ($p['alphaThreshold'] < 0 || $p['alphaThreshold'] > 255) {
+            throw new InvalidArgumentException('Transition alphaThreshold must be in the range 0..255');
+        }
+
+        return $p;
+    }
+
+
+    /**
+     * Класифицира всички пиксели на растера.
+     *
+     * @param \ImageColorAnalyzer\Contracts\Raster $raster
+     * @param array                                $params виж self::$defaults
+     *
+     * @return stdClass {mask, width, height, analyzedCount, solidCount, aaCount, transitionCount}
+     */
+    public static function classify($raster, array $params = array())
+    {
+        $p = self::normalizeParams($params);
+
+        $w = $raster->width();
+        $h = $raster->height();
+        $n = $w * $h;
+        $span = $p['span'];
+        $alphaThr = $p['alphaThreshold'];
+
+        // Пас A: пълните пикселни данни като бинарен низ (4 байта/пиксел,
+        // big-endian ARGB) - позволява произволен достъп без PHP масив за
+        // всеки пиксел (паметта следва 4N байта).
+        $data = '';
+        $rowBuf = array();
+        $x = 0;
+        foreach ($raster->pixels() as $px) {
+            $rowBuf[] = ($px->a << 24) | ($px->r << 16) | ($px->g << 8) | $px->b;
+            if (++$x === $w) {
+                $data .= pack('N*', ...$rowBuf);
+                $rowBuf = array();
+                $x = 0;
+            }
+        }
+
+        // Етап 1: кохерентен дрейф -> CHANGING (маркиран като CLS_AA)
+        $stage1 = str_repeat(self::CLS_SOLID, $n);
+        $analyzed = 0;
+        $rows = array();
+        $floor = $p['noiseDeltaE'];
+        $cosMin = $p['coherenceMin'];
+
+        for ($y = 0; $y < $h; $y++) {
+            if (!isset($rows[$y])) {
+                $rows[$y] = array_values(unpack('N*', substr($data, $y * $w * 4, $w * 4)));
+            }
+            $rowC = $rows[$y];
+            $rowU = null;
+            $rowD = null;
+            if ($y - $span >= 0 && $y + $span < $h) {
+                if (!isset($rows[$y + $span])) {
+                    $rows[$y + $span] = array_values(unpack('N*', substr($data, ($y + $span) * $w * 4, $w * 4)));
+                }
+                $rowU = $rows[$y - $span];
+                $rowD = $rows[$y + $span];
+            }
+            $base = $y * $w;
+
+            for ($x = 0; $x < $w; $x++) {
+                $vc = $rowC[$x];
+                if (($vc >> 24) < $alphaThr) {
+                    $stage1[$base + $x] = self::CLS_BG;
+                    continue;
+                }
+                $analyzed++;
+
+                $changing = false;
+                if ($x - $span >= 0 && $x + $span < $w) {
+                    $va = $rowC[$x - $span];
+                    $vb = $rowC[$x + $span];
+                    if (($va >> 24) >= $alphaThr && ($vb >> 24) >= $alphaThr && !($va === $vc && $vb === $vc)) {
+                        $changing = self::coherentDrift($va, $vc, $vb, $floor, $cosMin);
+                    }
+                }
+                if (!$changing && $rowU !== null) {
+                    $va = $rowU[$x];
+                    $vb = $rowD[$x];
+                    if (($va >> 24) >= $alphaThr && ($vb >> 24) >= $alphaThr && !($va === $vc && $vb === $vc)) {
+                        $changing = self::coherentDrift($va, $vc, $vb, $floor, $cosMin);
+                    }
+                }
+                if ($changing) {
+                    $stage1[$base + $x] = self::CLS_AA;
+                }
+            }
+
+            unset($rows[$y - $span]);
+        }
+
+        // Етап 2: ерозия с плъзгащи се суми по колони -> seeds
+        $mask = $stage1;
+        $r = $p['aaRadius'];
+        $minSeed = $p['minSeed'];
+        $queue = array();
+        $transitionCount = 0;
+
+        $colChg = array_fill(0, $w, 0);
+        $colSol = array_fill(0, $w, 0);
+        for ($yy = 0; $yy <= $r && $yy < $h; $yy++) {
+            self::tallyRow($stage1, $yy * $w, $w, $colChg, $colSol, 1);
+        }
+
+        for ($y = 0; $y < $h; $y++) {
+            if ($y > 0) {
+                if ($y + $r < $h) {
+                    self::tallyRow($stage1, ($y + $r) * $w, $w, $colChg, $colSol, 1);
+                }
+                if ($y - $r - 1 >= 0) {
+                    self::tallyRow($stage1, ($y - $r - 1) * $w, $w, $colChg, $colSol, -1);
+                }
+            }
+
+            $sumChg = 0;
+            $sumSol = 0;
+            for ($x = 0; $x <= $r && $x < $w; $x++) {
+                $sumChg += $colChg[$x];
+                $sumSol += $colSol[$x];
+            }
+            $base = $y * $w;
+            for ($x = 0; $x < $w; $x++) {
+                if ($x > 0) {
+                    if ($x + $r < $w) {
+                        $sumChg += $colChg[$x + $r];
+                        $sumSol += $colSol[$x + $r];
+                    }
+                    if ($x - $r - 1 >= 0) {
+                        $sumChg -= $colChg[$x - $r - 1];
+                        $sumSol -= $colSol[$x - $r - 1];
+                    }
+                }
+                $i = $base + $x;
+                if ($stage1[$i] === self::CLS_AA && $sumSol === 0 && $sumChg >= $minSeed) {
+                    $mask[$i] = self::CLS_TRANS;
+                    $queue[] = $i;
+                    $transitionCount++;
+                }
+            }
+        }
+
+        // Етап 3: 8-свързана реконструкция от seeds по CHANGING, блокирана
+        // при твърд ръб; блокираните се маркират, за да се тестват веднъж.
+        $edgeCap = $p['edgeDeltaE'];
+        $head = 0;
+        while ($head < count($queue)) {
+            $i = $queue[$head++];
+            $cy = intdiv($i, $w);
+            $cx = $i - $cy * $w;
+            for ($dy = -1; $dy <= 1; $dy++) {
+                $ny = $cy + $dy;
+                if ($ny < 0 || $ny >= $h) {
+                    continue;
+                }
+                for ($dx = -1; $dx <= 1; $dx++) {
+                    if ($dx === 0 && $dy === 0) {
+                        continue;
+                    }
+                    $nx = $cx + $dx;
+                    if ($nx < 0 || $nx >= $w) {
+                        continue;
+                    }
+                    $j = $ny * $w + $nx;
+                    if ($mask[$j] !== self::CLS_AA) {
+                        continue;
+                    }
+                    if (self::isHardEdge($data, $nx, $ny, $w, $h, $alphaThr, $edgeCap)) {
+                        $mask[$j] = self::CLS_BLOCKED;
+                        continue;
+                    }
+                    $mask[$j] = self::CLS_TRANS;
+                    $queue[] = $j;
+                    $transitionCount++;
+                }
+            }
+        }
+        if ($head > 0) {
+            $mask = strtr($mask, array(self::CLS_BLOCKED => self::CLS_AA));
+        }
+
+        // Етап 4: пазач по минимално покритие
+        if ($analyzed === 0 || $transitionCount / $analyzed < $p['minCoverage']) {
+            if ($transitionCount > 0) {
+                $mask = strtr($mask, array(self::CLS_TRANS => self::CLS_AA));
+            }
+            $transitionCount = 0;
+        }
+
+        $result = new stdClass();
+        $result->mask = $mask;
+        $result->width = $w;
+        $result->height = $h;
+        $result->analyzedCount = $analyzed;
+        $result->solidCount = substr_count($mask, self::CLS_SOLID);
+        $result->aaCount = substr_count($mask, self::CLS_AA);
+        $result->transitionCount = $transitionCount;
+
+        return $result;
+    }
+
+
+    /**
+     * Диагностична визуализация на маската: плътно=сиво, AA=червено,
+     * преливка=синьо, фон=прозрачно. Само за тестове/CLI инспекция.
+     *
+     * @param stdClass $cls резултат от classify()
+     *
+     * @return string PNG байтове
+     */
+    public static function renderMaskPng($cls)
+    {
+        $im = imagecreatetruecolor($cls->width, $cls->height);
+        imagealphablending($im, false);
+        imagesavealpha($im, true);
+
+        $colors = array(
+            self::CLS_BG => imagecolorallocatealpha($im, 0, 0, 0, 127),
+            self::CLS_SOLID => imagecolorallocatealpha($im, 200, 200, 200, 0),
+            self::CLS_AA => imagecolorallocatealpha($im, 220, 40, 40, 0),
+            self::CLS_TRANS => imagecolorallocatealpha($im, 40, 80, 220, 0),
+        );
+
+        $i = 0;
+        for ($y = 0; $y < $cls->height; $y++) {
+            for ($x = 0; $x < $cls->width; $x++) {
+                imagesetpixel($im, $x, $y, $colors[$cls->mask[$i++]]);
+            }
+        }
+
+        ob_start();
+        imagepng($im);
+
+        return ob_get_clean();
+    }
+
+
+    /**
+     * Кохерентен дрейф по една ос: двете полу-разлики около центъра трябва
+     * да са достатъчно големи средно и еднопосочни в Lab+alpha пространството.
+     *
+     * @param int   $va     опакован ARGB на пробата "преди"
+     * @param int   $vc     опакован ARGB на центъра
+     * @param int   $vb     опакован ARGB на пробата "след"
+     * @param float $floor  noiseDeltaE
+     * @param float $cosMin coherenceMin
+     *
+     * @return bool
+     */
+    private static function coherentDrift($va, $vc, $vb, $floor, $cosMin)
+    {
+        $la = self::lab($va & 0xFFFFFF);
+        $lc = self::lab($vc & 0xFFFFFF);
+        $lb = self::lab($vb & 0xFFFFFF);
+        $aa = ($va >> 24) * 100 / 255;
+        $ac = ($vc >> 24) * 100 / 255;
+        $ab = ($vb >> 24) * 100 / 255;
+
+        $v10 = $lc[0] - $la[0];
+        $v11 = $lc[1] - $la[1];
+        $v12 = $lc[2] - $la[2];
+        $v13 = $ac - $aa;
+        $v20 = $lb[0] - $lc[0];
+        $v21 = $lb[1] - $lc[1];
+        $v22 = $lb[2] - $lc[2];
+        $v23 = $ab - $ac;
+
+        $n1 = sqrt($v10 * $v10 + $v11 * $v11 + $v12 * $v12 + $v13 * $v13);
+        $n2 = sqrt($v20 * $v20 + $v21 * $v21 + $v22 * $v22 + $v23 * $v23);
+
+        if (($n1 + $n2) / 2 < $floor || $n1 < 1e-9 || $n2 < 1e-9) {
+
+            return false;
+        }
+
+        $dot = $v10 * $v20 + $v11 * $v21 + $v12 * $v22 + $v13 * $v23;
+
+        return $dot / ($n1 * $n2) >= $cosMin;
+    }
+
+
+    /**
+     * Дали пикселът лежи на твърд ръб: максималната разлика (deltaE или
+     * alpha, в проценти) до 4-те му съседа надхвърля $edgeCap.
+     *
+     * @param string $data     опакованите пикселни данни (4 байта/пиксел)
+     * @param int    $x
+     * @param int    $y
+     * @param int    $w
+     * @param int    $h
+     * @param int    $alphaThr
+     * @param float  $edgeCap
+     *
+     * @return bool
+     */
+    private static function isHardEdge($data, $x, $y, $w, $h, $alphaThr, $edgeCap)
+    {
+        $vc = unpack('N', substr($data, ($y * $w + $x) * 4, 4))[1];
+        $lc = self::lab($vc & 0xFFFFFF);
+        $acAlpha = ($vc >> 24) * 100 / 255;
+
+        foreach (array(array(-1, 0), array(1, 0), array(0, -1), array(0, 1)) as $d) {
+            $nx = $x + $d[0];
+            $ny = $y + $d[1];
+            if ($nx < 0 || $ny < 0 || $nx >= $w || $ny >= $h) {
+                continue;
+            }
+            $vn = unpack('N', substr($data, ($ny * $w + $nx) * 4, 4))[1];
+            if (($vn >> 24) < $alphaThr) {
+                continue;
+            }
+            $alphaDiff = abs(($vn >> 24) * 100 / 255 - $acAlpha);
+            if ($alphaDiff > $edgeCap) {
+
+                return true;
+            }
+            $ln = self::lab($vn & 0xFFFFFF);
+            $dE = sqrt(($lc[0] - $ln[0]) ** 2 + ($lc[1] - $ln[1]) ** 2 + ($lc[2] - $ln[2]) ** 2);
+            if ($dE > $edgeCap) {
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    /**
+     * CIELAB на 24-битов RGB с ограничен кеш.
+     *
+     * @param int $rgb24
+     *
+     * @return array array(L, a, b)
+     */
+    private static function lab($rgb24)
+    {
+        if (isset(self::$labMemo[$rgb24])) {
+
+            return self::$labMemo[$rgb24];
+        }
+
+        if (self::$converter === null) {
+            self::$converter = new \ImageColorAnalyzer\Color\ColorConverter();
+        }
+
+        $lab = self::$converter->rgbToLab(new \ImageColorAnalyzer\Contracts\ColorRGBA(
+            ($rgb24 >> 16) & 0xFF,
+            ($rgb24 >> 8) & 0xFF,
+            $rgb24 & 0xFF
+        ));
+
+        if (count(self::$labMemo) < self::LAB_MEMO_CAP) {
+            self::$labMemo[$rgb24] = $lab;
+        }
+
+        return $lab;
+    }
+
+
+    /**
+     * Добавя/изважда броенията на един ред от колонните суми на ерозията.
+     *
+     * @param string $stage1 маската от етап 1
+     * @param int    $offset начало на реда в маската
+     * @param int    $w
+     * @param array  $colChg колонни суми CHANGING (по референция)
+     * @param array  $colSol колонни суми SOLID (по референция)
+     * @param int    $sign   +1 добавяне, -1 изваждане
+     */
+    private static function tallyRow($stage1, $offset, $w, array &$colChg, array &$colSol, $sign)
+    {
+        for ($x = 0; $x < $w; $x++) {
+            $b = $stage1[$offset + $x];
+            if ($b === self::CLS_AA) {
+                $colChg[$x] += $sign;
+            } elseif ($b === self::CLS_SOLID) {
+                $colSol[$x] += $sign;
+            }
+        }
+    }
 }

--- a/imgcolor/TransitionClassifier.class.php
+++ b/imgcolor/TransitionClassifier.class.php
@@ -74,6 +74,22 @@ class imgcolor_TransitionClassifier
 
 
     /**
+     * Съпоставяне на override полетата в профилен запис (imgcolor_Profiles)
+     * с имената на параметрите. Празна стойност (null/'') означава
+     * "използвай глобалната конфигурация".
+     */
+    public static $overrideFields = array(
+        'transSpan' => 'span',
+        'transNoiseDeltaE' => 'noiseDeltaE',
+        'transCoherenceMin' => 'coherenceMin',
+        'transAaRadius' => 'aaRadius',
+        'transMinSeed' => 'minSeed',
+        'transEdgeDeltaE' => 'edgeDeltaE',
+        'transMinCoverage' => 'minCoverage',
+    );
+
+
+    /**
      * @var \ImageColorAnalyzer\Color\ColorConverter|null
      */
     private static $converter;
@@ -139,6 +155,33 @@ class imgcolor_TransitionClassifier
         }
 
         return $p;
+    }
+
+
+    /**
+     * Наслагва override стойности от профилен запис или масив върху базови
+     * параметри: само trans* полетата, само непразните стойности.
+     * Валидацията остава на normalizeParams() при употреба.
+     *
+     * @param array        $params базови параметри (напр. от глобалната конфигурация)
+     * @param object|array $source запис на imgcolor_Profiles или масив
+     *
+     * @return array
+     */
+    public static function applyOverrides(array $params, $source)
+    {
+        foreach (self::$overrideFields as $field => $param) {
+            if (is_array($source)) {
+                $value = isset($source[$field]) ? $source[$field] : null;
+            } else {
+                $value = isset($source->{$field}) ? $source->{$field} : null;
+            }
+            if ($value !== null && $value !== '') {
+                $params[$param] = $value;
+            }
+        }
+
+        return $params;
     }
 
 
@@ -368,6 +411,7 @@ class imgcolor_TransitionClassifier
 
         $result = new stdClass();
         $result->mask = $mask;
+        $result->params = $p;
         $result->width = $w;
         $result->height = $h;
         $result->analyzedCount = $analyzed;

--- a/imgcolor/docs/integration.md
+++ b/imgcolor/docs/integration.md
@@ -3,13 +3,42 @@
 ## What this package is
 A BGERP wrapper around the vendored, unmodified `image-color-analyzer`
 library. It crops the near-white background of a PNG/JPEG and reports the
-principal print colors with coverage percentages.
+principal print colors with coverage percentages. Since v0.4 it can also
+*separate* solid (spot-printable) colors from transitions (преливки):
+gradient/continuous-tone pixels are excluded from the solid list and
+accumulated into a CMYK ink-composition result instead. Design and calibrated
+thresholds: `docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.md`.
 
 ## Entry points
 - Service (any PHP caller / other module):
   - `imgcolor_Analyzer::analyzePath($path)` / `::analyze($bytesOrSource)`
   - `imgcolor_Analyzer::analyzeAsJson(...)` / `::analyzePathAsJson(...)`
   - `imgcolor_Analyzer::process($bytesOrSource)` -> ProcessedImageResult (json + cropped PNG bytes)
+  - `imgcolor_Analyzer::processSeparated($bytesOrSource)` -> stdClass
+    `{json, cmykJson, croppedImage, boundingBox, wasCropped}`. `json` lists
+    only solid colors (percentages over the solid+AA area, still summing to
+    100); `cmykJson` is null when the image has no transitions, otherwise:
+
+    ```json
+    {
+      "transition_coverage_percent": 31.2,
+      "composition_percent": {"c": 41.3, "m": 30.1, "y": 20.4, "k": 8.2},
+      "ink_total": 12345.678,
+      "raw_channels": {"c": 1.0, "m": 2.0, "y": 3.0, "k": 4.0},
+      "conversion": {
+        "engine": "math",
+        "source_profile": "assumed-sRGB",
+        "destination_profile": null,
+        "fallback": true,
+        "version": 1
+      }
+    }
+    ```
+
+    `composition_percent` sums to exactly 100.0 (largest-remainder rounding);
+    when `ink_total` is 0 (e.g. a white-to-transparent fade) all four values
+    are 0.0. For images without genuine transitions `json` is byte-identical
+    to the legacy `process()` output (regression-tested).
 - LLM tool:
   - `imgcolor_Analyzer::analyzeFileHandle($fh)` -> JSON
   - `imgcolor_Analyzer::getToolDefinition()` -> `{name, description, parameters}`
@@ -127,6 +156,48 @@ value comes from*.
 | `IMGCOLOR_CLUSTER_SEED` | `1` | `ClusterOptions::$seed` |
 | `IMGCOLOR_CLUSTER_ALPHA_THRESHOLD` | `8` | `ClusterOptions::$alphaThreshold` |
 
+### Transition classification (CMYK separation)
+
+All thresholds feed `imgcolor_TransitionClassifier` via
+`imgcolor_Analyzer::getTransParams()`; ranges are validated on options build
+and by `imgcolor_Setup::checkConfig()`. Calibration evidence for the defaults
+is in the design spec (§4).
+
+| Constant | Default | Units / effect |
+|---|---:|---|
+| `IMGCOLOR_TRANS_SPAN` | `4` | px; sampling distance of the coherent-drift test. Detectability bound: gradients shallower than ~noiseDeltaE/span ΔE per px read as solid. |
+| `IMGCOLOR_TRANS_NOISE_DELTAE` | `1.0` | CIE76 ΔE (+alpha%); minimum average half-difference to count as changing |
+| `IMGCOLOR_TRANS_COHERENCE_MIN` | `0.4` | cosine; both half-differences must point the same way (rejects JPEG noise/ringing) |
+| `IMGCOLOR_TRANS_AA_RADIUS` | `3` | px; erosion radius - bands narrower than 2r+1 px (AA ramps, blurred edges) never become transitions |
+| `IMGCOLOR_TRANS_MIN_SEED` | `20` | px; minimum changing pixels in the erosion window to seed a region |
+| `IMGCOLOR_TRANS_EDGE_DELTAE` | `10.0` | ΔE; reconstruction/dilation stops at harder edges |
+| `IMGCOLOR_TRANS_MIN_COVERAGE` | `0.005` | fraction; smaller transition areas are folded back to the solid path |
+
+### CMYK conversion
+
+| Constant | Default | Meaning |
+|---|---:|---|
+| `IMGCOLOR_CMYK_ENGINE` | `auto` | `auto` uses Imagick+ICC when available and configured, else the documented math formula (recorded as `fallback: true`); `imagick` requires ICC and fails loudly; `math` forces the formula |
+| `IMGCOLOR_CMYK_ICC_RGB_PROFILE` | empty | path to the source RGB ICC profile (e.g. sRGB IEC61966-2.1) |
+| `IMGCOLOR_CMYK_ICC_CMYK_PROFILE` | empty | path to the destination CMYK ICC profile (e.g. ECI ISOcoated_v2_300) |
+
+No ICC profiles ship with the package - obtain them separately (the ECI
+profiles are freely redistributable from eci.org) and point the constants at
+the files. The result metadata records the profile basenames + MD5 for
+reproducibility. The math formula (`K = 1 - max(R',G',B')`, `C = (1-R'-K)/(1-K)`,
+...) is an approximation and is **not** press-accurate; treat its output as an
+indicator, not a proof. Embedded source profiles are not honored (the GD
+decode path strips them); sources are assumed sRGB.
+
+### Semantics note (v0.4)
+
+For images that contain transitions, the solid-color list changes meaning:
+transition pixels no longer surface as pseudo-solid swatches, and solid
+percentages are relative to the solid+AA area only. Anti-aliased edges and
+narrow blurred edges stay in the solid path (absorbed by cluster merging,
+as before). Analysis history records created before v0.4 keep their old
+semantics; they are not migrated.
+
 ## Tests
 
 The framework-free regressions require PHP 8.2+ with GD and can run without a
@@ -138,11 +209,19 @@ php imgcolor/tests/cli_calibration.php
 php imgcolor/tests/cli_analysis_snapshot.php
 php imgcolor/tests/cli_init_signature.php
 php imgcolor/tests/cli_parity.php
+php imgcolor/tests/cli_separation.php
 ```
 
+`cli_separation.php` carries the full classifier fixture battery (solid, AA,
+blurred edges, JPEG noise/ringing, all gradient families, alpha fades, mixed
+scenes), the CMYK converter/accumulator units, the solid-path byte-parity
+regression, and a performance probe. `imgcolor_TransitionClassifier::renderMaskPng()`
+produces a diagnostic class-mask PNG (solid=gray, AA=red, transition=blue)
+for inspecting disputed classifications.
+
 The web unit runner (`?Ctr=unit_Tests`) provides the Fileman/database-backed
-coverage in `imgcolor_tests_Analyzer`, `imgcolor_tests_Profiles`, and
-`imgcolor_tests_Analyses`.
+coverage in `imgcolor_tests_Analyzer`, `imgcolor_tests_Profiles`,
+`imgcolor_tests_Analyses`, and `imgcolor_tests_Separation`.
 
 ## Updating the library
 Replace `lib/image-color-analyzer/src/` with the new upstream `src/`, update

--- a/imgcolor/docs/integration.md
+++ b/imgcolor/docs/integration.md
@@ -40,8 +40,12 @@ thresholds: `docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.m
     are 0.0. For images without genuine transitions `json` is byte-identical
     to the legacy `process()` output (regression-tested).
 - LLM tool:
-  - `imgcolor_Analyzer::analyzeFileHandle($fh)` -> JSON
+  - `imgcolor_Analyzer::analyzeFileHandle($fh)` -> JSON (legacy, un-separated)
   - `imgcolor_Analyzer::getToolDefinition()` -> `{name, description, parameters}`
+  - `imgcolor_Analyzer::analyzeSeparatedFileHandle($fh)` -> JSON envelope
+    `{"colors": [...], "cmyk": {...}|null}` (separated view)
+  - `imgcolor_Analyzer::getSeparatedToolDefinition()` ->
+    `analyze_image_print_colors_separated` descriptor
 - UI: `imgcolor_Demo` (menu `Инструменти -> Цветове за печат`) + a fileman
   file-action button on PNG/JPEG files. The analysis form exposes the complete
   calibration set: selecting a profile loads its values, and the displayed
@@ -172,6 +176,13 @@ is in the design spec (§4).
 | `IMGCOLOR_TRANS_MIN_SEED` | `20` | px; minimum changing pixels in the erosion window to seed a region |
 | `IMGCOLOR_TRANS_EDGE_DELTAE` | `10.0` | ΔE; reconstruction/dilation stops at harder edges |
 | `IMGCOLOR_TRANS_MIN_COVERAGE` | `0.005` | fraction; smaller transition areas are folded back to the solid path |
+
+Per-profile overrides: `imgcolor_Profiles` carries optional `trans*` fields
+(empty = use the global constant). A selected profile's overrides are applied
+by `imgcolor_Analyzer::getTransParams($profileRec)`; the actually used
+(normalized) thresholds are embedded in every CMYK payload under
+`"classifier"`, next to the `"conversion"` block, so historical results stay
+auditable after config or profile edits.
 
 ### CMYK conversion
 

--- a/imgcolor/tests/Separation.class.php
+++ b/imgcolor/tests/Separation.class.php
@@ -88,6 +88,48 @@ class imgcolor_tests_Separation extends unit_Class
 
 
     /**
+     * Профилен override на праговете влияе на разделния анализ.
+     */
+    public static function test_ProfileOverridesSuppressTransitions($us)
+    {
+        $png = self::createGradientPng();
+
+        $profileRec = new stdClass();
+        $profileRec->transNoiseDeltaE = 20.0;
+
+        $result = imgcolor_Analyzer::processSeparated($png, null, imgcolor_Analyzer::getTransParams($profileRec));
+        ut::expectEqual(null, $result->cmykJson);
+
+        // без override преливката се отчита
+        $result = imgcolor_Analyzer::processSeparated($png);
+        ut::expectEqual(true, is_string($result->cmykJson));
+        $cmyk = json_decode($result->cmykJson, true);
+        ut::expectEqual(true, isset($cmyk['classifier']['noiseDeltaE']));
+    }
+
+
+    /**
+     * LLM tool за разделен анализ: envelope с colors + cmyk.
+     */
+    public static function test_SeparatedFileHandleTool($us)
+    {
+        $fh = fileman::absorbStr(self::createGradientPng(), self::$bucket, 'tool-gradient.png');
+
+        $envelope = json_decode(imgcolor_Analyzer::analyzeSeparatedFileHandle($fh), true);
+        ut::expectEqual(true, is_array($envelope['colors']));
+        ut::expectEqual(true, is_array($envelope['cmyk']));
+
+        $def = imgcolor_Analyzer::getSeparatedToolDefinition();
+        ut::expectEqual('analyze_image_print_colors_separated', $def['name']);
+        ut::expectEqual(true, in_array('fileHandle', $def['parameters']['required'], true));
+
+        // legacy tool контрактът остава непроменен
+        $legacyDef = imgcolor_Analyzer::getToolDefinition();
+        ut::expectEqual('analyze_image_print_colors', $legacyDef['name']);
+    }
+
+
+    /**
      * Създава PNG с хоризонтална преливка червено -> синьо.
      *
      * @return string PNG байтове

--- a/imgcolor/tests/Separation.class.php
+++ b/imgcolor/tests/Separation.class.php
@@ -1,0 +1,112 @@
+<?php
+
+
+/**
+ * Тестове за разделния анализ (CMYK отделяне на преливките)
+ *
+ * Пуска се през уеб контролера unit_Tests (?Ctr=unit_Tests), не през CLI.
+ * Framework-free покритието на класификатора/акумулатора е в
+ * tests/cli_separation.php.
+ *
+ * @package imgcolor
+ */
+class imgcolor_tests_Separation extends unit_Class
+{
+    /**
+     * Името на тестовата кофа
+     */
+    public static $bucket = 'imgcolorImages';
+
+
+    /**
+     * Подготвя кофата, ако пакетът още не е инсталиран в тестовата среда.
+     */
+    public function __construct()
+    {
+        fileman_Buckets::createBucket(self::$bucket, 'Изображения за цветови анализ', 'jpg,jpeg,png', '50MB', 'imgcolor,ceo,admin', 'imgcolor,ceo,admin');
+    }
+
+
+    /**
+     * Изображение без преливки: разделният резултат е байт-идентичен с
+     * legacy пътя и няма CMYK payload.
+     */
+    public static function test_SolidImageKeepsLegacyOutput($us)
+    {
+        $fixture = dirname(__DIR__) . '/tests/fixtures/sample.png';
+
+        $result = imgcolor_Analyzer::processSeparated(file_get_contents($fixture));
+
+        ut::expectEqual(imgcolor_Analyzer::analyzePathAsJson($fixture), $result->json);
+        ut::expectEqual(null, $result->cmykJson);
+    }
+
+
+    /**
+     * Изображение с преливка: CMYK payload със състав, сумиращ точно 100.0,
+     * и отделено покритие на прехода.
+     */
+    public static function test_GradientProducesCmykPayload($us)
+    {
+        $result = imgcolor_Analyzer::processSeparated(self::createGradientPng());
+
+        ut::expectEqual(true, is_string($result->cmykJson));
+        $cmyk = json_decode($result->cmykJson, true);
+        $sum = 0.0;
+        foreach ($cmyk['composition_percent'] as $v) {
+            $sum += $v;
+        }
+        ut::expectEqual(100.0, round($sum, 1));
+        ut::expectEqual(true, $cmyk['transition_coverage_percent'] > 50);
+        ut::expectEqual(true, isset($cmyk['conversion']['engine']));
+    }
+
+
+    /**
+     * Историята пази cmykJson и го рендира; запис без CMYK не показва блока.
+     */
+    public static function test_HistoryRoundTripsCmykJson($us)
+    {
+        $fh = fileman::absorbStr(self::createGradientPng(), self::$bucket, 'gradient.png');
+
+        $result = imgcolor_Analyzer::processSeparated(fileman::extractStr($fh));
+        imgcolor_Demo::persistResult($fh, null, $result, imgcolor_Calibration::getDefaultValues());
+
+        $query = imgcolor_Analyses::getQuery();
+        $query->orderBy('#id', 'DESC');
+        $rec = $query->fetch();
+
+        ut::expectEqual($result->cmykJson, $rec->cmykJson);
+        ut::expectEqual(true, strpos(imgcolor_Analyses::renderRec($rec), 'CMYK') !== false);
+
+        // legacy-съвместимо извикване без cmykJson
+        $id = imgcolor_Analyses::createFromResult($fh, null, '[]');
+        $legacyRec = imgcolor_Analyses::fetch($id);
+        ut::expectEqual(true, empty($legacyRec->cmykJson));
+        ut::expectEqual(false, strpos((string) imgcolor_Analyses::renderRec($legacyRec), 'CMYK'));
+    }
+
+
+    /**
+     * Създава PNG с хоризонтална преливка червено -> синьо.
+     *
+     * @return string PNG байтове
+     */
+    private static function createGradientPng()
+    {
+        $im = imagecreatetruecolor(128, 64);
+        imagealphablending($im, false);
+        imagesavealpha($im, true);
+        for ($x = 0; $x < 128; $x++) {
+            $r = (int) round(200 + (30 - 200) * $x / 127);
+            $g = (int) round(30 + (60 - 30) * $x / 127);
+            $b = (int) round(30 + (200 - 30) * $x / 127);
+            imageline($im, $x, 0, $x, 63, imagecolorallocatealpha($im, $r, $g, $b, 0));
+        }
+
+        ob_start();
+        imagepng($im);
+
+        return ob_get_clean();
+    }
+}

--- a/imgcolor/tests/cli_analysis_snapshot.php
+++ b/imgcolor/tests/cli_analysis_snapshot.php
@@ -67,5 +67,14 @@ $legacy = core_Manager::$savedRec;
 if (isset($legacy->calibrationJson) && $legacy->calibrationJson !== null) {
     fail('legacy-compatible call should leave the calibration snapshot empty');
 }
+if (isset($legacy->cmykJson) && $legacy->cmykJson !== null) {
+    fail('legacy-compatible call should leave the CMYK payload empty');
+}
+
+imgcolor_Analyses::createFromResult('cmykFh', null, '[]', null, null, '{"ink_total":1.5}');
+$withCmyk = core_Manager::$savedRec;
+if ($withCmyk->cmykJson !== '{"ink_total":1.5}') {
+    fail('CMYK payload must be persisted verbatim');
+}
 
 echo "PASS: analysis history stores exact calibration snapshots\n";

--- a/imgcolor/tests/cli_separation.php
+++ b/imgcolor/tests/cli_separation.php
@@ -106,3 +106,94 @@ if (!extension_loaded('imagick')) {
 }
 
 echo "PASS: cli_separation section 1 (converter)\n";
+
+// ---------------------------------------------------------------------------
+// 2) CMYK accumulator: alpha weighting, largest-remainder 100.0, zero ink
+// ---------------------------------------------------------------------------
+
+require_once __DIR__ . '/../TransitionClassifier.class.php';
+require_once __DIR__ . '/../CmykAccumulator.class.php';
+
+/**
+ * Builds an InMemoryRaster + hand-made classification over a pixel spec list:
+ * each entry: array(r, g, b, a255, classByte).
+ */
+function accumFixture(array $pixels)
+{
+    $colors = array();
+    $mask = '';
+    foreach ($pixels as $p) {
+        $colors[] = new \ImageColorAnalyzer\Contracts\ColorRGBA($p[0], $p[1], $p[2], $p[3]);
+        $mask .= $p[4];
+    }
+    $raster = new \ImageColorAnalyzer\ImageLoader\InMemoryRaster(count($pixels), 1, $colors);
+    $cls = new stdClass();
+    $cls->mask = $mask;
+    $cls->analyzedCount = 0;
+    $cls->transitionCount = 0;
+    foreach ($pixels as $p) {
+        if ($p[4] !== imgcolor_TransitionClassifier::CLS_BG) {
+            $cls->analyzedCount++;
+        }
+        if ($p[4] === imgcolor_TransitionClassifier::CLS_TRANS) {
+            $cls->transitionCount++;
+        }
+    }
+
+    return array($raster, $cls);
+}
+
+$T = imgcolor_TransitionClassifier::CLS_TRANS;
+$S = imgcolor_TransitionClassifier::CLS_SOLID;
+$B = imgcolor_TransitionClassifier::CLS_BG;
+
+// no transitions -> null
+list($raster, $cls) = accumFixture(array(array(10, 20, 30, 255, $S)));
+if (imgcolor_CmykAccumulator::accumulate($raster, $cls, $math) !== null) {
+    fail('no transitions must yield null');
+}
+
+// pure red + pure cyan transitions, solid/background pixels excluded
+list($raster, $cls) = accumFixture(array(
+    array(255, 0, 0, 255, $T),   // math: C0 M1 Y1 K0
+    array(0, 255, 255, 255, $T), // math: C1 M0 Y0 K0
+    array(0, 0, 0, 255, $S),     // solid: excluded (would add K)
+    array(0, 0, 0, 255, $B),     // background: excluded
+));
+$res = imgcolor_CmykAccumulator::accumulate($raster, $cls, $math);
+if ($res === null) {
+    fail('transitions present must yield a result');
+}
+$sum = $res['composition_percent']['c'] + $res['composition_percent']['m']
+     + $res['composition_percent']['y'] + $res['composition_percent']['k'];
+approx($sum, 100.0, 0.001, 'composition must sum to exactly 100.0');
+approx($res['composition_percent']['c'], 33.3, 0.11, 'cyan share');
+approx($res['composition_percent']['k'], 0.0, 0.001, 'solid black pixel must not leak into K');
+approx($res['transition_coverage_percent'], 66.7, 0.11, 'coverage = 2 of 3 analyzed');
+approx($res['ink_total'], 3.0, 0.001, 'raw ink total');
+if ($res['conversion']['engine'] !== 'math') {
+    fail('conversion metadata must be embedded');
+}
+
+// alpha weighting: half-transparent red deposits half the ink of opaque red
+list($raster, $cls) = accumFixture(array(
+    array(255, 0, 0, 255, $T),
+    array(255, 0, 0, 128, $T),
+));
+$res = imgcolor_CmykAccumulator::accumulate($raster, $cls, $math);
+approx($res['ink_total'], 2 * (1 + 128 / 255), 0.01, 'alpha-weighted ink total');
+
+// zero ink: white-only transition reports zeros, no division by zero
+list($raster, $cls) = accumFixture(array(array(255, 255, 255, 200, $T)));
+$res = imgcolor_CmykAccumulator::accumulate($raster, $cls, $math);
+if ($res['ink_total'] != 0.0) {
+    fail('white transition must accumulate zero ink');
+}
+foreach (array('c', 'm', 'y', 'k') as $ch) {
+    if ($res['composition_percent'][$ch] !== 0.0) {
+        fail('zero-ink composition must be all zeros');
+    }
+}
+approx($res['transition_coverage_percent'], 100.0, 0.001, 'zero-ink coverage still reported');
+
+echo "PASS: cli_separation section 2 (accumulator)\n";

--- a/imgcolor/tests/cli_separation.php
+++ b/imgcolor/tests/cli_separation.php
@@ -732,3 +732,75 @@ printf("PERF: 1200x800 mixed separation in %.2fs, peak %.0f MB, transition %.1f%
     microtime(true) - $t0, memory_get_peak_usage(true) / 1048576, $sep->cmyk === null ? 0 : $sep->cmyk['transition_coverage_percent']);
 
 echo "PASS: cli_separation section 5 (orchestrator)\n";
+
+// ---------------------------------------------------------------------------
+// 6) Profile overrides of transition thresholds + classifier audit block
+// ---------------------------------------------------------------------------
+
+$defaults = imgcolor_TransitionClassifier::$defaults;
+
+// object source (as an imgcolor_Profiles record): empty values are ignored
+$rec = new stdClass();
+$rec->transSpan = 6;
+$rec->transNoiseDeltaE = '';
+$rec->transMinCoverage = 0.25;
+$rec->unrelated = 99;
+$merged = imgcolor_TransitionClassifier::applyOverrides($defaults, $rec);
+if ($merged['span'] !== 6 || $merged['minCoverage'] !== 0.25) {
+    fail('object overrides must apply non-empty trans* fields');
+}
+if ($merged['noiseDeltaE'] !== $defaults['noiseDeltaE']) {
+    fail('empty override must keep the base value');
+}
+if (array_keys($merged) !== array_keys($defaults)) {
+    fail('overrides must not introduce foreign keys');
+}
+
+// array source works the same way
+$merged = imgcolor_TransitionClassifier::applyOverrides($defaults, array('transAaRadius' => 5));
+if ($merged['aaRadius'] !== 5) {
+    fail('array overrides must apply');
+}
+
+// invalid override values surface through normalizeParams with the field name
+try {
+    imgcolor_TransitionClassifier::normalizeParams(
+        imgcolor_TransitionClassifier::applyOverrides($defaults, array('transSpan' => 99))
+    );
+    fail('out-of-range override must be rejected');
+} catch (InvalidArgumentException $e) {
+    if (strpos($e->getMessage(), 'span') === false) {
+        fail('override rejection must name the parameter');
+    }
+}
+
+// the cmyk payload records the actually used (normalized) classifier params
+$im = mkImg(128, 64);
+for ($x = 0; $x < 128; $x++) {
+    $c = lerpC(array(200, 30, 30), array(30, 60, 200), $x / 127);
+    for ($y = 0; $y < 64; $y++) {
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+$sep = separateGd($im);
+if (!isset($sep->cmyk['classifier']) || $sep->cmyk['classifier']['span'] !== $defaults['span']) {
+    fail('cmyk payload must embed the normalized classifier params');
+}
+
+// a prohibitive noise-floor override folds everything back to the solid path
+$loader = new \ImageColorAnalyzer\ImageLoader\GdImageLoader();
+$resolver = new \ImageColorAnalyzer\ImageLoader\SourceResolver();
+ob_start();
+imagepng($im);
+$raster = $loader->load($resolver->resolve(ob_get_clean()));
+$sep = imgcolor_Separation::process(
+    $raster,
+    new \ImageColorAnalyzer\Options\AnalyzerOptions(),
+    imgcolor_TransitionClassifier::applyOverrides($defaults, array('transNoiseDeltaE' => 20.0)),
+    new imgcolor_CmykConverter(array('engine' => 'math', 'rgbProfile' => '', 'cmykProfile' => ''))
+);
+if ($sep->cmyk !== null) {
+    fail('noiseDeltaE=20 override must suppress the CMYK result');
+}
+
+echo "PASS: cli_separation section 6 (profile overrides)\n";

--- a/imgcolor/tests/cli_separation.php
+++ b/imgcolor/tests/cli_separation.php
@@ -197,3 +197,332 @@ foreach (array('c', 'm', 'y', 'k') as $ch) {
 approx($res['transition_coverage_percent'], 100.0, 0.001, 'zero-ink coverage still reported');
 
 echo "PASS: cli_separation section 2 (accumulator)\n";
+
+// ---------------------------------------------------------------------------
+// 3) Transition classifier: fixture battery (ported from the calibration
+//    prototype; expected rates from docs/superpowers/specs/...-design.md)
+// ---------------------------------------------------------------------------
+
+function mkImg($w, $h, $bg = array(255, 255, 255))
+{
+    $im = imagecreatetruecolor($w, $h);
+    imagealphablending($im, false);
+    imagesavealpha($im, true);
+    $c = $bg === null
+        ? imagecolorallocatealpha($im, 0, 0, 0, 127)
+        : imagecolorallocatealpha($im, $bg[0], $bg[1], $bg[2], 0);
+    imagefilledrectangle($im, 0, 0, $w - 1, $h - 1, $c);
+
+    return $im;
+}
+
+function setPx($im, $x, $y, $r, $g, $b, $a255 = 255)
+{
+    $ga = 127 - (int) round($a255 * 127 / 255);
+    imagesetpixel($im, $x, $y, imagecolorallocatealpha($im, $r, $g, $b, $ga));
+}
+
+function lerpC(array $c1, array $c2, $t)
+{
+    return array(
+        (int) round($c1[0] + ($c2[0] - $c1[0]) * $t),
+        (int) round($c1[1] + ($c2[1] - $c1[1]) * $t),
+        (int) round($c1[2] + ($c2[2] - $c1[2]) * $t),
+    );
+}
+
+function aaDisk($size, array $fg, $bg)
+{
+    $ss = 4;
+    $big = mkImg($size * $ss, $size * $ss, $bg);
+    imagefilledellipse($big, (int) ($size * $ss / 2), (int) ($size * $ss / 2), (int) ($size * $ss * 0.75), (int) ($size * $ss * 0.75), imagecolorallocatealpha($big, $fg[0], $fg[1], $fg[2], 0));
+    $out = imagecreatetruecolor($size, $size);
+    imagealphablending($out, false);
+    imagesavealpha($out, true);
+    imagecopyresampled($out, $big, 0, 0, 0, 0, $size, $size, $size * $ss, $size * $ss);
+
+    return $out;
+}
+
+function jpegRoundtrip($im, $q)
+{
+    ob_start();
+    imagejpeg($im, null, $q);
+    $out = imagecreatefromstring(ob_get_clean());
+    imagealphablending($out, false);
+    imagesavealpha($out, true);
+
+    return $out;
+}
+
+/** @return stdClass classification for a GD image with default (or overridden) params */
+function classifyImg($im, array $overrides = array())
+{
+    $raster = new \ImageColorAnalyzer\ImageLoader\GdRaster($im);
+
+    return imgcolor_TransitionClassifier::classify($raster, $overrides);
+}
+
+/** transition share of analyzed pixels, percent */
+function transShare($cls)
+{
+    return $cls->analyzedCount ? 100 * $cls->transitionCount / $cls->analyzedCount : 0.0;
+}
+
+/** transition share within a pixel rectangle, percent */
+function transShareRect($cls, $x1, $y1, $x2, $y2)
+{
+    $n = 0;
+    $t = 0;
+    for ($y = $y1; $y <= $y2; $y++) {
+        for ($x = $x1; $x <= $x2; $x++) {
+            $b = $cls->mask[$y * $cls->width + $x];
+            if ($b === imgcolor_TransitionClassifier::CLS_BG) {
+                continue;
+            }
+            $n++;
+            if ($b === imgcolor_TransitionClassifier::CLS_TRANS) {
+                $t++;
+            }
+        }
+    }
+
+    return $n ? 100 * $t / $n : 0.0;
+}
+
+// -- solid / AA / noise fixtures: zero transitions expected ------------------
+
+$im = mkImg(64, 64, array(190, 30, 140));
+if (transShare(classifyImg($im)) != 0.0) {
+    fail('solid_single must have no transitions');
+}
+
+$im = mkImg(96, 96, array(220, 40, 40));
+imagefilledrectangle($im, 48, 0, 95, 95, imagecolorallocatealpha($im, 30, 60, 200, 0));
+imagefilledrectangle($im, 0, 48, 47, 95, imagecolorallocatealpha($im, 30, 180, 90, 0));
+if (transShare(classifyImg($im)) != 0.0) {
+    fail('solid_multi (hard edges) must have no transitions');
+}
+
+if (transShare(classifyImg(aaDisk(96, array(200, 30, 30), array(255, 255, 255)))) != 0.0) {
+    fail('aa disk on white must have no transitions');
+}
+
+$cls = classifyImg(aaDisk(96, array(200, 30, 30), null));
+if (transShare($cls) != 0.0) {
+    fail('aa disk on transparent must have no transitions');
+}
+if ($cls->analyzedCount >= 96 * 96) {
+    fail('transparent background must not count as analyzed');
+}
+
+foreach (array(1, 2) as $aw) {
+    $im = mkImg(96, 48, array(230, 30, 30));
+    $blue = array(30, 60, 200);
+    imagefilledrectangle($im, 48 + $aw, 0, 95, 47, imagecolorallocatealpha($im, $blue[0], $blue[1], $blue[2], 0));
+    for ($i = 0; $i < $aw; $i++) {
+        $c = lerpC(array(230, 30, 30), $blue, ($i + 1) / ($aw + 1));
+        for ($y = 0; $y < 48; $y++) {
+            setPx($im, 48 + $i, $y, $c[0], $c[1], $c[2]);
+        }
+    }
+    if (transShare(classifyImg($im)) != 0.0) {
+        fail("aa_edge_{$aw}px must have no transitions");
+    }
+}
+
+$im = mkImg(96, 48, array(230, 30, 30));
+imagefilledrectangle($im, 48, 0, 95, 47, imagecolorallocatealpha($im, 30, 60, 200, 0));
+for ($pass = 0; $pass < 3; $pass++) {
+    imagefilter($im, IMG_FILTER_GAUSSIAN_BLUR);
+}
+if (transShare(classifyImg($im)) != 0.0) {
+    fail('blurred hard edge must not read as a design gradient');
+}
+
+$im = mkImg(128, 96, array(235, 235, 235));
+imagefilledrectangle($im, 20, 20, 107, 75, imagecolorallocatealpha($im, 200, 30, 30, 0));
+imagefilledellipse($im, 64, 48, 40, 30, imagecolorallocatealpha($im, 30, 60, 200, 0));
+approx(transShare(classifyImg(jpegRoundtrip($im, 60))), 0.0, 0.6, 'jpeg q60 flat artwork false transitions');
+
+$im = mkImg(128, 96, array(255, 255, 255));
+imagefilledellipse($im, 64, 48, 70, 50, imagecolorallocatealpha($im, 10, 10, 10, 0));
+approx(transShare(classifyImg(jpegRoundtrip($im, 55))), 0.0, 0.6, 'jpeg q55 ringing false transitions');
+
+$im = mkImg(200, 200, array(240, 240, 240));
+for ($x = 0; $x < 10; $x++) {
+    $c = lerpC(array(255, 0, 0), array(0, 0, 255), $x / 9);
+    for ($y = 0; $y < 10; $y++) {
+        setPx($im, 95 + $x, 95 + $y, $c[0], $c[1], $c[2]);
+    }
+}
+if (transShare(classifyImg($im)) != 0.0) {
+    fail('sub-coverage gradient must be folded by the guard');
+}
+
+// -- gradient fixtures: high recall expected ---------------------------------
+
+$im = mkImg(128, 64);
+for ($x = 0; $x < 128; $x++) {
+    $c = lerpC(array(200, 30, 30), array(30, 60, 200), $x / 127);
+    for ($y = 0; $y < 64; $y++) {
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+if (transShare(classifyImg($im)) < 85) {
+    fail('linear gradient recall below 85%');
+}
+
+$im = mkImg(96, 96);
+for ($y = 0; $y < 96; $y++) {
+    for ($x = 0; $x < 96; $x++) {
+        $t = ($x + $y) / 190;
+        $c = lerpC(array(10, 90, 170), array(240, 240, 240), $t);
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+if (transShare(classifyImg($im)) < 90) {
+    fail('diagonal gradient recall below 90%');
+}
+
+$im = mkImg(128, 48);
+for ($x = 0; $x < 128; $x++) {
+    $v = (int) round(255 * $x / 127);
+    for ($y = 0; $y < 48; $y++) {
+        setPx($im, $x, $y, $v, $v, $v);
+    }
+}
+if (transShare(classifyImg($im)) < 85) {
+    fail('grayscale gradient recall below 85%');
+}
+
+$im = mkImg(200, 40);
+$stops = array(array(228, 3, 3), array(255, 140, 0), array(255, 237, 0), array(0, 128, 38), array(36, 64, 142));
+for ($x = 0; $x < 200; $x++) {
+    $t = $x / 199 * 4;
+    $i = min(3, (int) $t);
+    $c = lerpC($stops[$i], $stops[$i + 1], $t - $i);
+    for ($y = 0; $y < 40; $y++) {
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+if (transShare(classifyImg($im)) < 85) {
+    fail('multi-stop gradient recall below 85%');
+}
+
+$im = mkImg(96, 96);
+for ($y = 0; $y < 96; $y++) {
+    for ($x = 0; $x < 96; $x++) {
+        $t = min(1.0, hypot($x - 48, $y - 48) / 48);
+        $c = lerpC(array(250, 220, 40), array(140, 20, 120), $t);
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+if (transShare(classifyImg($im)) < 70) {
+    fail('radial gradient recall below 70%');
+}
+
+$im = mkImg(96, 48, array(128, 128, 128));
+for ($x = 40; $x < 56; $x++) {
+    $c = lerpC(array(0, 0, 0), array(255, 255, 255), ($x - 40) / 15);
+    for ($y = 0; $y < 48; $y++) {
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+$cls = classifyImg($im);
+if (transShareRect($cls, 40, 0, 55, 47) < 40) {
+    fail('steep 16px ramp core must be at least 40% transition');
+}
+if (transShareRect($cls, 0, 0, 33, 47) > 1 || transShareRect($cls, 62, 0, 95, 47) > 1) {
+    fail('steep ramp must not leak transitions into the surrounding solid');
+}
+
+$im = mkImg(128, 48);
+for ($x = 0; $x < 128; $x++) {
+    $c = lerpC(array(255, 255, 255), array(200, 30, 30), $x / 127);
+    for ($y = 0; $y < 48; $y++) {
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+if (transShare(classifyImg($im)) < 85) {
+    fail('white-containing gradient recall below 85%');
+}
+
+foreach (array(array(255, 255, 255), array(200, 30, 140)) as $fadeColor) {
+    $im = mkImg(128, 48, null);
+    for ($x = 0; $x < 128; $x++) {
+        $a = (int) round(255 * (1 - $x / 127));
+        for ($y = 0; $y < 48; $y++) {
+            setPx($im, $x, $y, $fadeColor[0], $fadeColor[1], $fadeColor[2], $a);
+        }
+    }
+    if (transShare(classifyImg($im)) < 85) {
+        fail('alpha fade recall below 85%');
+    }
+}
+
+$im = mkImg(96, 96);
+for ($y = 0; $y < 96; $y++) {
+    for ($x = 0; $x < 96; $x++) {
+        $v = (sin($x / 7.3) + cos($y / 5.1) + sin(($x + $y) / 11.7)) / 3;
+        $c = lerpC(array(60, 80, 60), array(200, 220, 180), ($v + 1) / 2);
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+if (transShare(classifyImg($im)) < 80) {
+    fail('continuous-tone texture must classify as transition content');
+}
+
+// -- mixed scene --------------------------------------------------------------
+
+$im = mkImg(192, 96, array(235, 235, 235));
+imagefilledrectangle($im, 0, 0, 63, 95, imagecolorallocatealpha($im, 30, 120, 60, 0));
+for ($x = 64; $x < 128; $x++) {
+    $c = lerpC(array(250, 210, 40), array(210, 40, 120), ($x - 64) / 63);
+    for ($y = 0; $y < 96; $y++) {
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+$disk = aaDisk(48, array(30, 60, 200), null);
+imagecopy($im, $disk, 138, 24, 0, 0, 48, 48);
+$cls = classifyImg($im);
+if (transShareRect($cls, 66, 0, 125, 95) < 85) {
+    fail('mixed: gradient band recall below 85%');
+}
+if (transShareRect($cls, 0, 0, 63, 95) > 1 || transShareRect($cls, 128, 0, 191, 95) > 1) {
+    fail('mixed: solid zones must stay below 1% false transitions');
+}
+
+// -- degenerate sizes and parameter validation --------------------------------
+
+foreach (array(array(1, 1), array(3, 3)) as $dim) {
+    $im = mkImg($dim[0], $dim[1], array(10, 200, 30));
+    $cls = classifyImg($im);
+    if ($cls->transitionCount !== 0 || $cls->analyzedCount !== $dim[0] * $dim[1]) {
+        fail("tiny {$dim[0]}x{$dim[1]} image must be all solid");
+    }
+}
+
+try {
+    imgcolor_TransitionClassifier::normalizeParams(array('span' => 0));
+    fail('span=0 must be rejected');
+} catch (InvalidArgumentException $e) {
+    if (strpos($e->getMessage(), 'span') === false) {
+        fail('span error message must name the field');
+    }
+}
+try {
+    imgcolor_TransitionClassifier::normalizeParams(array('minCoverage' => 1.0));
+    fail('minCoverage=1.0 must be rejected');
+} catch (InvalidArgumentException $e) {
+    // expected
+}
+
+// -- debug mask render ---------------------------------------------------------
+
+$png = imgcolor_TransitionClassifier::renderMaskPng($cls);
+if (substr($png, 0, 4) !== "\x89PNG") {
+    fail('renderMaskPng must return PNG bytes');
+}
+
+echo "PASS: cli_separation section 3 (classifier)\n";

--- a/imgcolor/tests/cli_separation.php
+++ b/imgcolor/tests/cli_separation.php
@@ -526,3 +526,51 @@ if (substr($png, 0, 4) !== "\x89PNG") {
 }
 
 echo "PASS: cli_separation section 3 (classifier)\n";
+
+// ---------------------------------------------------------------------------
+// 4) Masked raster: hides only the skipped class from pixels()
+// ---------------------------------------------------------------------------
+
+require_once __DIR__ . '/../MaskedRaster.class.php';
+
+$im = mkImg(8, 4, array(200, 30, 30));
+setPx($im, 0, 0, 30, 60, 200);
+setPx($im, 1, 0, 30, 60, 200);
+$raster = new \ImageColorAnalyzer\ImageLoader\GdRaster($im);
+
+// mask: two TRANS pixels at offsets 0 and 1, rest SOLID
+$mask = str_repeat(imgcolor_TransitionClassifier::CLS_SOLID, 32);
+$mask[0] = imgcolor_TransitionClassifier::CLS_TRANS[0];
+$mask[1] = imgcolor_TransitionClassifier::CLS_TRANS[0];
+
+$masked = new imgcolor_MaskedRaster($raster, $mask);
+$histogram = new \ImageColorAnalyzer\ColorClusterer\ColorHistogram();
+$full = $histogram->build($raster, 5, 8);
+$part = $histogram->build($masked, 5, 8);
+if ($full['total'] !== 32 || $part['total'] !== 30) {
+    fail("masked histogram totals: expected 32/30, got {$full['total']}/{$part['total']}");
+}
+foreach ($part['colors'] as $c) {
+    if ($c[2] > 150) {
+        fail('masked-out blue pixels must not reach the histogram');
+    }
+}
+
+// an all-solid mask is fully transparent to the histogram
+$noop = new imgcolor_MaskedRaster($raster, str_repeat(imgcolor_TransitionClassifier::CLS_SOLID, 32));
+if ($histogram->build($noop, 5, 8) !== $full) {
+    fail('no-op mask must not change the histogram');
+}
+
+// dimensions delegate; wrong mask length rejected
+if ($masked->width() !== 8 || $masked->height() !== 4) {
+    fail('masked raster must delegate dimensions');
+}
+try {
+    new imgcolor_MaskedRaster($raster, 'short');
+    fail('mask length mismatch must be rejected');
+} catch (InvalidArgumentException $e) {
+    // expected
+}
+
+echo "PASS: cli_separation section 4 (masked raster)\n";

--- a/imgcolor/tests/cli_separation.php
+++ b/imgcolor/tests/cli_separation.php
@@ -574,3 +574,161 @@ try {
 }
 
 echo "PASS: cli_separation section 4 (masked raster)\n";
+
+// ---------------------------------------------------------------------------
+// 5) Separation orchestrator: byte parity on solid inputs, true separation
+//    on mixed inputs, transparency, determinism, performance probe
+// ---------------------------------------------------------------------------
+
+require_once __DIR__ . '/../Separation.class.php';
+
+$JSON_FLAGS = JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION;
+
+function separatePath($path)
+{
+    $loader = new \ImageColorAnalyzer\ImageLoader\GdImageLoader();
+    $resolver = new \ImageColorAnalyzer\ImageLoader\SourceResolver();
+    $raster = $loader->load($resolver->resolvePath($path));
+    $math = new imgcolor_CmykConverter(array('engine' => 'math', 'rgbProfile' => '', 'cmykProfile' => ''));
+
+    return imgcolor_Separation::process($raster, new \ImageColorAnalyzer\Options\AnalyzerOptions(), array(), $math);
+}
+
+function separateGd($im)
+{
+    ob_start();
+    imagepng($im);
+    $bytes = ob_get_clean();
+    $loader = new \ImageColorAnalyzer\ImageLoader\GdImageLoader();
+    $resolver = new \ImageColorAnalyzer\ImageLoader\SourceResolver();
+    $raster = $loader->load($resolver->resolve($bytes));
+    $math = new imgcolor_CmykConverter(array('engine' => 'math', 'rgbProfile' => '', 'cmykProfile' => ''));
+
+    return imgcolor_Separation::process($raster, new \ImageColorAnalyzer\Options\AnalyzerOptions(), array(), $math);
+}
+
+$legacy = \ImageColorAnalyzer\PublicAPI\AnalyzerFactory::createDefault();
+
+// byte parity on the repository fixtures (no transitions in either)
+foreach (array('sample.png', 'sample_transparent.png') as $fixture) {
+    $path = __DIR__ . '/fixtures/' . $fixture;
+    $sep = separatePath($path);
+    $legacyJson = $legacy->analyzePathAsJson($path);
+    $sepJson = json_encode($sep->colors, $JSON_FLAGS);
+    if ($sepJson !== $legacyJson) {
+        fail("{$fixture}: separated colors must be byte-identical to the legacy path");
+    }
+    if ($sep->cmyk !== null) {
+        fail("{$fixture}: no transitions expected");
+    }
+}
+
+// byte parity on a synthetic solid-multi image with AA edges
+$im = mkImg(96, 96, array(220, 40, 40));
+imagefilledrectangle($im, 48, 0, 95, 95, imagecolorallocatealpha($im, 30, 60, 200, 0));
+$disk = aaDisk(48, array(30, 120, 60), array(220, 40, 40));
+imagecopy($im, $disk, 4, 44, 0, 0, 48, 48);
+ob_start();
+imagepng($im);
+$solidBytes = ob_get_clean();
+$sep = separateGd($im);
+if (json_encode($sep->colors, $JSON_FLAGS) !== $legacy->analyzeAsJson($solidBytes)) {
+    fail('solid+AA synthetic: separated colors must be byte-identical to the legacy path');
+}
+if ($sep->cmyk !== null) {
+    fail('solid+AA synthetic: no transitions expected');
+}
+
+// mixed scene: gradient band leaves the solid list and lands in CMYK
+$im = mkImg(192, 96, array(30, 120, 60));
+for ($x = 64; $x < 128; $x++) {
+    $c = lerpC(array(250, 210, 40), array(210, 40, 120), ($x - 64) / 63);
+    for ($y = 0; $y < 96; $y++) {
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+imagefilledrectangle($im, 128, 0, 191, 95, imagecolorallocatealpha($im, 30, 60, 200, 0));
+$sep = separateGd($im);
+if ($sep->cmyk === null) {
+    fail('mixed: CMYK result expected');
+}
+$sum = 0.0;
+foreach ($sep->cmyk['composition_percent'] as $v) {
+    $sum += $v;
+}
+approx($sum, 100.0, 0.001, 'mixed: composition must sum to 100.0');
+if ($sep->cmyk['transition_coverage_percent'] < 25 || $sep->cmyk['transition_coverage_percent'] > 40) {
+    fail('mixed: transition coverage out of expected band: ' . $sep->cmyk['transition_coverage_percent']);
+}
+// solid list: only green and blue solids, no gradient centroids
+$expectedSolids = array(array(30, 120, 60), array(30, 60, 200));
+foreach ($sep->colors as $c) {
+    if (!preg_match('/^#([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})$/', $c['color'], $m)) {
+        fail('mixed: malformed color ' . $c['color']);
+    }
+    $rgb = array(hexdec($m[1]), hexdec($m[2]), hexdec($m[3]));
+    $near = false;
+    foreach ($expectedSolids as $s) {
+        if (abs($rgb[0] - $s[0]) + abs($rgb[1] - $s[1]) + abs($rgb[2] - $s[2]) < 60) {
+            $near = true;
+        }
+    }
+    if (!$near) {
+        fail('mixed: unexpected pseudo-solid from the gradient band: ' . $c['color']);
+    }
+}
+$sum = 0.0;
+foreach ($sep->colors as $c) {
+    $sum += $c['coverage_percent'];
+}
+approx($sum, 100.0, 0.11, 'mixed: solid coverage still sums to ~100 over the solid area');
+
+// gradient-only image: CMYK covers nearly everything
+$im = mkImg(128, 64);
+for ($x = 0; $x < 128; $x++) {
+    $c = lerpC(array(200, 30, 30), array(30, 60, 200), $x / 127);
+    for ($y = 0; $y < 64; $y++) {
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+$sep = separateGd($im);
+if ($sep->cmyk === null || $sep->cmyk['transition_coverage_percent'] < 85) {
+    fail('gradient-only: CMYK coverage below 85%');
+}
+
+// fully transparent image: both results empty
+$im = mkImg(4, 4, null);
+$sep = separateGd($im);
+if ($sep->colors !== array() || $sep->cmyk !== null) {
+    fail('fully transparent image must yield empty colors and no CMYK');
+}
+
+// determinism: identical serialized output across runs
+$im = mkImg(192, 96, array(30, 120, 60));
+for ($x = 64; $x < 128; $x++) {
+    $c = lerpC(array(250, 210, 40), array(210, 40, 120), ($x - 64) / 63);
+    for ($y = 0; $y < 96; $y++) {
+        setPx($im, $x, $y, $c[0], $c[1], $c[2]);
+    }
+}
+$a = separateGd($im);
+$b = separateGd($im);
+if (json_encode($a->colors, $JSON_FLAGS) !== json_encode($b->colors, $JSON_FLAGS)
+    || json_encode($a->cmyk) !== json_encode($b->cmyk)) {
+    fail('separation must be deterministic');
+}
+
+// performance probe (reported, not asserted)
+$im = mkImg(1200, 800, array(235, 235, 235));
+imagefilledrectangle($im, 0, 0, 399, 799, imagecolorallocatealpha($im, 30, 120, 60, 0));
+for ($x = 400; $x < 800; $x++) {
+    $c = lerpC(array(250, 210, 40), array(210, 40, 120), ($x - 400) / 399);
+    imageline($im, $x, 0, $x, 799, imagecolorallocatealpha($im, $c[0], $c[1], $c[2], 0));
+}
+imagefilledellipse($im, 1000, 400, 300, 300, imagecolorallocatealpha($im, 30, 60, 200, 0));
+$t0 = microtime(true);
+$sep = separateGd($im);
+printf("PERF: 1200x800 mixed separation in %.2fs, peak %.0f MB, transition %.1f%%\n",
+    microtime(true) - $t0, memory_get_peak_usage(true) / 1048576, $sep->cmyk === null ? 0 : $sep->cmyk['transition_coverage_percent']);
+
+echo "PASS: cli_separation section 5 (orchestrator)\n";

--- a/imgcolor/tests/cli_separation.php
+++ b/imgcolor/tests/cli_separation.php
@@ -1,0 +1,108 @@
+<?php
+
+// Framework-free regression for the CMYK separation feature: classifier,
+// masked raster, CMYK converter/accumulator, and the bgERP-free orchestrator.
+// Requires PHP 8.2+ with GD; no bgERP instance needed (like cli_parity.php).
+// Usage: php imgcolor/tests/cli_separation.php
+
+$libBase = __DIR__ . '/../lib/image-color-analyzer/src/';
+
+spl_autoload_register(function ($class) use ($libBase) {
+    $prefix = 'ImageColorAnalyzer\\';
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return;
+    }
+
+    $rel = substr($class, strlen($prefix));
+    $file = $libBase . str_replace('\\', '/', $rel) . '.php';
+    if (is_file($file)) {
+        include_once $file;
+    }
+});
+
+require_once __DIR__ . '/../CmykConverter.class.php';
+
+function fail($msg)
+{
+    fwrite(STDERR, "FAIL: {$msg}\n");
+    exit(1);
+}
+
+function approx($a, $b, $tol, $what)
+{
+    if (abs($a - $b) > $tol) {
+        fail("{$what}: expected ~{$b}, got {$a}");
+    }
+}
+
+if (!extension_loaded('gd')) {
+    fail('ext-gd is not loaded in this CLI php');
+}
+
+// ---------------------------------------------------------------------------
+// 1) CMYK converter: math engine vectors, engine selection, metadata
+// ---------------------------------------------------------------------------
+
+$math = new imgcolor_CmykConverter(array('engine' => 'math', 'rgbProfile' => '', 'cmykProfile' => ''));
+
+$vectors = array(
+    array(array(255, 0, 0), array(0.0, 1.0, 1.0, 0.0)),
+    array(array(0, 255, 0), array(1.0, 0.0, 1.0, 0.0)),
+    array(array(0, 0, 255), array(1.0, 1.0, 0.0, 0.0)),
+    array(array(0, 0, 0), array(0.0, 0.0, 0.0, 1.0)),
+    array(array(255, 255, 255), array(0.0, 0.0, 0.0, 0.0)),
+    array(array(128, 128, 128), array(0.0, 0.0, 0.0, 1 - 128 / 255)),
+    array(array(255, 128, 0), array(0.0, 0.498, 1.0, 0.0)),
+);
+$in = array();
+foreach ($vectors as $v) {
+    $in[] = $v[0];
+}
+$out = $math->convert($in);
+if (count($out) !== count($in)) {
+    fail('converter must return one CMYK per input color');
+}
+foreach ($vectors as $i => $v) {
+    foreach (array('c', 'm', 'y', 'k') as $ch => $name) {
+        approx($out[$i][$ch], $v[1][$ch], 0.002, "math cmyk {$name} for rgb(" . implode(',', $v[0]) . ')');
+    }
+}
+if ($math->convert(array()) !== array()) {
+    fail('empty input must yield empty output');
+}
+
+$meta = $math->getMetadata();
+if ($meta['engine'] !== 'math' || $meta['fallback'] !== false || $meta['version'] !== 1
+    || $meta['source_profile'] !== 'assumed-sRGB' || $meta['destination_profile'] !== null) {
+    fail('math engine metadata mismatch: ' . json_encode($meta));
+}
+
+// auto without imagick/profiles degrades to math and records the fallback
+$auto = new imgcolor_CmykConverter(array('engine' => 'auto', 'rgbProfile' => '', 'cmykProfile' => ''));
+$meta = $auto->getMetadata();
+if ($meta['engine'] === 'math' && $meta['fallback'] !== true) {
+    fail('auto->math degradation must set fallback=true');
+}
+
+// invalid engine name rejected
+try {
+    new imgcolor_CmykConverter(array('engine' => 'lcms', 'rgbProfile' => '', 'cmykProfile' => ''));
+    fail('invalid engine must be rejected');
+} catch (InvalidArgumentException $e) {
+    if (strpos($e->getMessage(), 'engine') === false) {
+        fail('engine error message must name the field');
+    }
+}
+
+// explicit imagick engine without prerequisites is a loud error, not a fallback
+if (!extension_loaded('imagick')) {
+    try {
+        new imgcolor_CmykConverter(array('engine' => 'imagick', 'rgbProfile' => '', 'cmykProfile' => ''));
+        fail('engine=imagick without ext-imagick must be rejected');
+    } catch (InvalidArgumentException $e) {
+        // expected
+    }
+    echo "NOTE: ext-imagick absent - ICC conversion exercised only via metadata/fallback logic\n";
+}
+
+echo "PASS: cli_separation section 1 (converter)\n";

--- a/imgcolor/tests/cli_separation.php
+++ b/imgcolor/tests/cli_separation.php
@@ -196,6 +196,60 @@ foreach (array('c', 'm', 'y', 'k') as $ch) {
 }
 approx($res['transition_coverage_percent'], 100.0, 0.001, 'zero-ink coverage still reported');
 
+// histogram-resolution binning: bounds memory to <= (2^bits)^3 bins instead
+// of up to 2^24, mirroring ImageColorAnalyzer\ColorClusterer\ColorHistogram
+class RecordingCmykConverterForTest extends imgcolor_CmykConverter
+{
+    public $lastColors = null;
+
+    public function convert(array $colors)
+    {
+        $this->lastColors = $colors;
+
+        return parent::convert($colors);
+    }
+}
+
+// two near colors fall into the same default (bits=5) bin and collapse into
+// one weighted-average representative before conversion
+$recorder = new RecordingCmykConverterForTest(array('engine' => 'math', 'rgbProfile' => '', 'cmykProfile' => ''));
+list($raster, $cls) = accumFixture(array(
+    array(0, 0, 0, 255, $T),
+    array(7, 0, 0, 255, $T),
+));
+$res = imgcolor_CmykAccumulator::accumulate($raster, $cls, $recorder);
+if (count($recorder->lastColors) !== 1) {
+    fail('near colors within the same histogram bin must collapse to one representative, got ' . count($recorder->lastColors) . ' bins');
+}
+if ($recorder->lastColors[0] !== array(4, 0, 0)) {
+    fail('bin representative must be the weighted average of its pixels: ' . json_encode($recorder->lastColors[0]));
+}
+$sum = $res['composition_percent']['c'] + $res['composition_percent']['m']
+     + $res['composition_percent']['y'] + $res['composition_percent']['k'];
+approx($sum, 100.0, 0.001, 'binned composition must still sum to exactly 100.0');
+
+// $bits is honored end-to-end: coarser quantization merges more, bits=8
+// (lossless for 8-bit channels) reproduces the pre-fix one-bin-per-color behavior
+list($raster, $cls) = accumFixture(array(
+    array(0, 0, 0, 255, $T),
+    array(100, 0, 0, 255, $T),
+    array(250, 0, 0, 255, $T),
+));
+$recorder = new RecordingCmykConverterForTest(array('engine' => 'math', 'rgbProfile' => '', 'cmykProfile' => ''));
+$res = imgcolor_CmykAccumulator::accumulate($raster, $cls, $recorder, 1);
+if (count($recorder->lastColors) !== 2) {
+    fail('bits=1 must merge (0,0,0) and (100,0,0) into one bin, keep (250,0,0) separate: got ' . count($recorder->lastColors) . ' bins');
+}
+$sum = $res['composition_percent']['c'] + $res['composition_percent']['m']
+     + $res['composition_percent']['y'] + $res['composition_percent']['k'];
+approx($sum, 100.0, 0.001, 'bits=1 composition must still sum to exactly 100.0');
+
+$recorder = new RecordingCmykConverterForTest(array('engine' => 'math', 'rgbProfile' => '', 'cmykProfile' => ''));
+imgcolor_CmykAccumulator::accumulate($raster, $cls, $recorder, 8);
+if (count($recorder->lastColors) !== 3) {
+    fail('bits=8 must keep all three distinct 8-bit colors in separate bins, got ' . count($recorder->lastColors) . ' bins');
+}
+
 echo "PASS: cli_separation section 2 (accumulator)\n";
 
 // ---------------------------------------------------------------------------

--- a/imgcolor/tests/cli_setup_bucket.php
+++ b/imgcolor/tests/cli_setup_bucket.php
@@ -50,8 +50,8 @@ require_once dirname(__DIR__) . '/Setup.class.php';
 $setup = new imgcolor_Setup();
 $setup->install();
 
-if ($setup->version !== '0.3') {
-    fail('package version must advance to 0.3 so existing installations rerun setup');
+if ($setup->version !== '0.4') {
+    fail('package version must advance to 0.4 so existing installations rerun setup');
 }
 
 $args = fileman_Buckets::$createArgs;


### PR DESCRIPTION
## Какво

Отделя преливките от плътните цветове в анализа на imgcolor, по изискването:

- Плътните (spot) цветове остават в съществуващия списък; за изображения без преливки резултатът е **байт-идентичен** с досегашния (регресионен тест, не допускане).
- Преливките (градиенти, continuous-tone, alpha фейдове) се класифицират пространствено и се натрупват в нов CMYK акумулатор: нормализиран състав C+M+Y+K = точно 100.0, отделно отчетено покритие на прехода, сурови канали и одитни метаданни (енджин, профили, класификационни прагове).
- Anti-aliasing ръбове, blur-нати ръбове и JPEG шум/ringing НЕ са преливки - остават при плътните цветове (0% false transitions върху фикстурите).

## Как

Нови wrapper класове (без промени под `imgcolor/lib/`): `imgcolor_TransitionClassifier` (кохерентен дрейф + ерозия + edge-capped реконструкция + ограничена дилатация + пазач по покритие), `imgcolor_MaskedRaster`, `imgcolor_CmykConverter` (Imagick ICC / math fallback, без бъндлвани профили), `imgcolor_CmykAccumulator`, `imgcolor_Separation`; `imgcolor_Analyzer::processSeparated()`; ново поле `imgcolor_Analyses.cmykJson`; CMYK секция в Demo; опционални per-profile override-и на праговете; отделен LLM tool `analyze_image_print_colors_separated`. Праговете са емпирично калибрирани върху 22 фикстури с ground truth; дизайн и измервания: `docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.md`.

## Тестове

```
php imgcolor/tests/cli_setup_bucket.php      PASS
php imgcolor/tests/cli_calibration.php       PASS
php imgcolor/tests/cli_analysis_snapshot.php PASS
php imgcolor/tests/cli_init_signature.php    PASS
php imgcolor/tests/cli_parity.php            PASS
php imgcolor/tests/cli_separation.php        PASS (класификатор, конвертор, акумулатор, byte-parity, детерминизъм, override-и; PERF: 1200x800 за ~1.3s / 14MB)
```

Уеб тестовете (`imgcolor_tests_Separation`) са добавени, но изискват работеща инстанция - не са пускани локално. ICC пътят на конвертора не е изпълняван локално (няма ext-imagick); селекцията/fallback логиката е тествана.

## Бележки за deployment

- Версията на пакета е вдигната на 0.4 - setup добавя полето `cmykJson` и новите `IMGCOLOR_TRANS_*` / `IMGCOLOR_CMYK_*` константи.
- За реална ICC конверсия: инсталирайте ext-imagick + ECI/sRGB профили и задайте `IMGCOLOR_CMYK_ICC_*` пътищата; иначе се ползва документираната math апроксимация (записва се като fallback в резултата).
- За изображения С преливки списъкът с плътни цветове сменя смисъла си (без псевдо-плътни от градиенти; процентите са спрямо плътната площ). Стари записи в историята не се мигрират.