### PR TITLE
fix(imgcolor): scale solid coverage to the analyzed area, not the solid area

### DIFF
--- a/imgcolor/Analyzer.class.php
+++ b/imgcolor/Analyzer.class.php
@@ -286,6 +286,8 @@ class imgcolor_Analyzer extends core_Mvc
     /**
      * Разделен анализ: плътните цветове остават в стандартния списък
      * (без преливките), а преливките се натрупват в CMYK акумулатор.
+     * Покритието на плътните цветове е спрямо анализираната площ - същата
+     * скала като transition_coverage_percent, така че двете сумират до 100%.
      * Изображения без преливки дават байт-идентичен colors JSON с process().
      *
      * @param mixed      $source      ImageSource, stream, raw bytes или GD image
@@ -445,6 +447,10 @@ class imgcolor_Analyzer extends core_Mvc
                            . 'list the solid (spot-printable) colors with coverage percentages, and '
                            . 'report gradients/continuous-tone areas separately as a normalized CMYK '
                            . 'ink composition (c+m+y+k = 100) with transition area coverage. '
+                           . 'Solid "coverage_percent" and "transition_coverage_percent" are both '
+                           . 'shares of the whole analyzed (non-transparent, cropped) area and sum '
+                           . 'to 100, so a solid color covering a fifth of an image that is mostly '
+                           . 'gradient reads as 20, not 50. '
                            . '"cmyk" is null when the image contains no gradients.',
             'parameters' => array(
                 'type' => 'object',

--- a/imgcolor/Demo.class.php
+++ b/imgcolor/Demo.class.php
@@ -309,12 +309,21 @@ class imgcolor_Demo extends core_Manager
         }
 
         $swatches = '';
+        $solidTotal = 0.0;
         foreach ($colors as $c) {
             $hex = preg_replace('/[^#0-9A-Fa-f]/', '', (string) $c['color']);
             $pct = (float) $c['coverage_percent'];
+            $solidTotal += $pct;
             $swatches .= "<div style='display:flex;align-items:center;gap:8px;margin:2px 0'>"
                 . "<span style='display:inline-block;width:20px;height:20px;border:1px solid #999;background:{$hex}'></span>"
                 . "<code>{$hex}</code> - {$pct}%</div>";
+        }
+
+        // Заглавие на скалата: процентите са спрямо анализираната площ, както
+        // и покритието на преливките - двата блока сумират до 100%.
+        if ($swatches !== '') {
+            $solidTotal = round($solidTotal, 1);
+            $swatches = '<b>' . tr('Плътни цветове') . ": {$solidTotal}% " . tr('от анализираната площ') . '</b>' . $swatches;
         }
 
         $imgTag = '';

--- a/imgcolor/Separation.class.php
+++ b/imgcolor/Separation.class.php
@@ -4,8 +4,9 @@
 /**
  * bgERP-независим оркестратор на разделния анализ: изрязване (библиотечен
  * cropper) -> класификация на преливките -> клъстеризиране на плътните
- * цветове (непроменен библиотечен път; при липса на преливки оригиналният
- * растер се подава директно за байт-идентичен резултат) -> CMYK акумулация.
+ * цветове (непроменен библиотечен клъстеризатор; при липса на преливки
+ * оригиналният растер се подава директно за байт-идентичен резултат) ->
+ * покритие спрямо анализираната площ -> CMYK акумулация.
  *
  * Тества се директно с `php imgcolor/tests/cli_separation.php`.
  *
@@ -48,14 +49,11 @@ class imgcolor_Separation
         );
         $clusters = $clusterer->cluster($clusterInput, $options->cluster);
 
-        $colors = array();
-        $coverage = new \ImageColorAnalyzer\CoverageCalculator\PercentageCoverageCalculator();
-        foreach ($coverage->calculate($clusters) as $item) {
-            $colors[] = $item->toArray();
-        }
-
         $result = new stdClass();
-        $result->colors = $colors;
+        // Покритието е спрямо анализираната площ, а не спрямо площта на
+        // плътните пиксели - иначе преливките изчезват от знаменателя и
+        // плътните проценти се раздуват (imgcolor_SolidCoverage).
+        $result->colors = imgcolor_SolidCoverage::calculate($clusters, $classification);
         $result->cmyk = imgcolor_CmykAccumulator::accumulate(
             $crop->raster,
             $classification,

--- a/imgcolor/SolidCoverage.class.php
+++ b/imgcolor/SolidCoverage.class.php
@@ -1,0 +1,130 @@
+<?php
+
+
+/**
+ * Покритие на плътните цветове като процент от цялата анализирана площ, не от
+ * площта на самите плътни пиксели: същият знаменател, който ползва и
+ * transition_coverage_percent на imgcolor_CmykAccumulator. Така плътните
+ * проценти и покритието на преливките се четат на една и съща скала и сумират
+ * точно до 100.0%.
+ *
+ * Библиотечният PercentageCoverageCalculator нормализира до 100% върху
+ * подадените на клъстеризатора пиксели. След маскирането на преливките този
+ * знаменател е по-малък от анализираната площ и процентите се раздуват - при
+ * изображение с 60% преливка плътен цвят върху 20% от площта би се отчел като
+ * 50%. Без преливки двата знаменателя съвпадат и резултатът е идентичен с
+ * библиотечния (регресия в cli_separation.php).
+ *
+ * Без bgERP зависимост - тества се директно с
+ * `php imgcolor/tests/cli_separation.php`.
+ *
+ * @category  bgerp
+ * @package   imgcolor
+ *
+ * @license   GPL 3
+ * @since     v 0.4
+ */
+class imgcolor_SolidCoverage
+{
+    /**
+     * Пълният бюджет в десети от процента (100.0% == 1000 десети)
+     */
+    const TENTHS_TOTAL = 1000;
+
+
+    /**
+     * Изчислява покритието на всеки клъстер спрямо анализираната площ.
+     *
+     * @param \ImageColorAnalyzer\Contracts\ClusterResult $result клъстерите на плътните пиксели
+     * @param stdClass                                    $cls    резултат от imgcolor_TransitionClassifier::classify()
+     *
+     * @return array [{color: "#RRGGBB", coverage_percent: float}, ...], в намаляващ ред
+     */
+    public static function calculate($result, $cls)
+    {
+        $analyzed = (int) $cls->analyzedCount;
+        if ($analyzed <= 0 || $result->clusters === array()) {
+
+            return array();
+        }
+
+        // Бюджетът на плътните цветове е допълнението на закръгления дял на
+        // преливките - взема се от същите броячи, за да не може плътни +
+        // преливки да покажат 99.9% или 100.1% от закръгляне поотделно.
+        $budget = self::TENTHS_TOTAL
+                - (int) round($cls->transitionCount / $analyzed * self::TENTHS_TOTAL);
+
+        $tenths = array();
+        $remainders = array();
+        $allocated = 0;
+        foreach ($result->clusters as $i => $cluster) {
+            $exact = $cluster->weight / $analyzed * self::TENTHS_TOTAL;
+            $floor = (int) floor($exact);
+            $tenths[$i] = $floor;
+            $remainders[$i] = $exact - $floor;
+            $allocated += $floor;
+        }
+
+        self::distributeRemainder($tenths, $remainders, $budget - $allocated, $result);
+
+        $colors = array();
+        foreach ($result->clusters as $i => $cluster) {
+            $colors[] = array(
+                'color' => $cluster->centroid->toHex(),
+                'coverage_percent' => $tenths[$i] / 10.0,
+            );
+        }
+
+        usort($colors, function ($a, $b) {
+            $byPercent = $b['coverage_percent'] <=> $a['coverage_percent'];
+
+            return $byPercent !== 0 ? $byPercent : strcmp($a['color'], $b['color']);
+        });
+
+        return $colors;
+    }
+
+
+    /**
+     * Най-голям остатък: остатъчните десети отиват при клъстерите с най-голяма
+     * дробна част, за да падне сумата точно на бюджета. Правилата за подредба
+     * (остатък, тегло, hex) следват PercentageCoverageCalculator на
+     * библиотеката, за да е идентичен резултатът при липса на преливки.
+     *
+     * @param array $tenths     модифицира се на място
+     * @param array $remainders дробните части
+     * @param int   $leftover   неразпределени десети
+     * @param \ImageColorAnalyzer\Contracts\ClusterResult $result
+     */
+    private static function distributeRemainder(array &$tenths, array $remainders, $leftover, $result)
+    {
+        // Долните цели части сумират най-много до бюджета, така че остатъкът е
+        // неотрицателен и по-малък от броя клъстери; горната граница пази от
+        // непоследователен $cls (broi(TRANS) + клъстеризирани != analyzedCount).
+        $leftover = min((int) $leftover, count($remainders));
+        if ($leftover <= 0) {
+
+            return;
+        }
+
+        $order = array_keys($remainders);
+        usort($order, function ($a, $b) use ($remainders, $result) {
+            $byRemainder = $remainders[$b] <=> $remainders[$a];
+            if ($byRemainder !== 0) {
+
+                return $byRemainder;
+            }
+            $byWeight = $result->clusters[$b]->weight <=> $result->clusters[$a]->weight;
+            if ($byWeight !== 0) {
+
+                return $byWeight;
+            }
+
+            return strcmp($result->clusters[$a]->centroid->toHex(), $result->clusters[$b]->centroid->toHex());
+        });
+
+        for ($i = 0; $i < $leftover; $i++) {
+            $tenths[$order[$i]]++;
+        }
+    }
+}

--- a/imgcolor/docs/integration.md
+++ b/imgcolor/docs/integration.md
@@ -16,8 +16,10 @@ thresholds: `docs/superpowers/specs/2026-07-13-imgcolor-cmyk-separation-design.m
   - `imgcolor_Analyzer::process($bytesOrSource)` -> ProcessedImageResult (json + cropped PNG bytes)
   - `imgcolor_Analyzer::processSeparated($bytesOrSource)` -> stdClass
     `{json, cmykJson, croppedImage, boundingBox, wasCropped}`. `json` lists
-    only solid colors (percentages over the solid+AA area, still summing to
-    100); `cmykJson` is null when the image has no transitions, otherwise:
+    only solid colors, each as a percentage **of the whole analyzed area** -
+    the same denominator as `transition_coverage_percent`, so the solid list
+    and the transition coverage sum to exactly 100.0 (`imgcolor_SolidCoverage`).
+    `cmykJson` is null when the image has no transitions, otherwise:
 
     ```json
     {
@@ -101,6 +103,7 @@ Profiles are shared records governed by the existing `imgcolor`, `ceo`, and
 | `imgcolor_Analyzer::makeAnalyzer()` | `PublicAPI\AnalyzerFactory::createDefault()` or explicit Imagick wiring | GD is default; Imagick still depends on GD for PNG decode/encode paths. |
 | `imgcolor_Analyzer::analyze*()` | `PublicAPI\ImageColorAnalyzer::analyze*()` | Returns the library array/JSON unchanged. |
 | `imgcolor_Analyzer::process*()` | `PublicAPI\ImageColorAnalyzer::process*()` | Returns the library `ProcessedImageResult` DTO unchanged. |
+| `imgcolor_SolidCoverage` | replaces `CoverageCalculator\PercentageCoverageCalculator` on the separated path | Same rounding, whole-analyzed-area denominator (see the v0.4 semantics note). The library class stays in use on the legacy `process()`/`analyze*()` path. |
 | `imgcolor_Analyzer::analyzeFileHandle($fh)` | `fileman::extractStr($fh)` -> `analyzeAsJson($bytes)` | Machine/LLM entry point; input is a fileman handle and output is JSON. |
 | `imgcolor_Demo` | `imgcolor_Analyzer::process($bytes, $options)` | Interactive analysis/calibration UI and fileman file-action button; persists every run via `imgcolor_Analyses::createFromResult()`. |
 | `imgcolor_Calibration` | `Options\CropOptions`, `Options\ClusterOptions`, `Options\AnalyzerOptions` | Authoritative field/default/record mapping through `getDefaultValues()`, `getValues()`, `applyValues()`, and `buildOptions()`. Standalone-testable: `php imgcolor/tests/cli_calibration.php`. |
@@ -203,11 +206,24 @@ decode path strips them); sources are assumed sRGB.
 ### Semantics note (v0.4)
 
 For images that contain transitions, the solid-color list changes meaning:
-transition pixels no longer surface as pseudo-solid swatches, and solid
-percentages are relative to the solid+AA area only. Anti-aliased edges and
-narrow blurred edges stay in the solid path (absorbed by cluster merging,
-as before). Analysis history records created before v0.4 keep their old
-semantics; they are not migrated.
+transition pixels no longer surface as pseudo-solid swatches, and every solid
+percentage is a share of the whole analyzed (non-transparent, cropped) area
+rather than of the solid area. On an image that is one third green, one third
+gradient, one third blue, the solids read 33.8% and 33.9% with the transitions
+at 32.3% - not 50/50 with the gradient invisible in the denominator. Solid
+percentages therefore no longer sum to 100 on their own; they sum to
+`100 - transition_coverage_percent`.
+
+The library's `PercentageCoverageCalculator` cannot express this (it always
+normalizes to 100 over the pixels handed to the clusterer, and the transition
+pixels are masked out before that), so the wrapper computes coverage in
+`imgcolor_SolidCoverage` instead - same largest-remainder rounding and
+tie-breaks, different denominator. With no transitions the two denominators
+coincide and the output is identical to the library's (regression-tested).
+
+Anti-aliased edges and narrow blurred edges stay in the solid path (absorbed
+by cluster merging, as before). Analysis history records created before v0.4
+keep their old semantics; they are not migrated.
 
 ## Tests
 

--- a/imgcolor/tests/cli_separation.php
+++ b/imgcolor/tests/cli_separation.php
@@ -630,10 +630,87 @@ try {
 echo "PASS: cli_separation section 4 (masked raster)\n";
 
 // ---------------------------------------------------------------------------
+// 4b) Solid coverage: percentages are shares of the analyzed area, not of the
+//     clustered (solid-only) area
+// ---------------------------------------------------------------------------
+
+require_once __DIR__ . '/../SolidCoverage.class.php';
+
+/** ClusterResult over a weights list, with a matching classification stub */
+function coverageFixture(array $weights, $transitionCount)
+{
+    $clusters = array();
+    foreach ($weights as $i => $w) {
+        // distinct centroids; the exact colors are irrelevant to the math
+        $rgb = new \ImageColorAnalyzer\Contracts\ColorRGBA(10 * ($i + 1), 20, 30, 255);
+        $clusters[] = new \ImageColorAnalyzer\Contracts\Cluster($rgb, array(0.0, 0.0, 0.0), $w);
+    }
+
+    $cls = new stdClass();
+    $cls->analyzedCount = array_sum($weights) + $transitionCount;
+    $cls->transitionCount = $transitionCount;
+
+    return array(new \ImageColorAnalyzer\Contracts\ClusterResult($clusters, array_sum($weights)), $cls);
+}
+
+/** @return float sum of coverage_percent */
+function coverageSum(array $colors)
+{
+    $sum = 0.0;
+    foreach ($colors as $c) {
+        $sum += $c['coverage_percent'];
+    }
+
+    return $sum;
+}
+
+// 200 solid px of one color + 800 transition px: the solid is 20% of the
+// image, not 100% of the solid area
+list($clusterResult, $cls) = coverageFixture(array(200), 800);
+$cov = imgcolor_SolidCoverage::calculate($clusterResult, $cls);
+approx($cov[0]['coverage_percent'], 20.0, 0.001, 'single solid over a mostly-transition image');
+
+// solids + transition coverage land on exactly 100.0 (no 99.9/100.1 artifacts
+// from independently rounded halves)
+list($clusterResult, $cls) = coverageFixture(array(211, 122, 34), 300);
+$cov = imgcolor_SolidCoverage::calculate($clusterResult, $cls);
+$transPct = round($cls->transitionCount / $cls->analyzedCount * 100, 1);
+approx(coverageSum($cov) + $transPct, 100.0, 0.001, 'solid + transition must sum to exactly 100.0');
+
+// ordering stays descending by share
+if ($cov[0]['coverage_percent'] < $cov[1]['coverage_percent'] || $cov[1]['coverage_percent'] < $cov[2]['coverage_percent']) {
+    fail('coverage must be sorted descending: ' . json_encode($cov));
+}
+
+// no transitions: the whole analyzed area is solid, so the list sums to 100.0
+// exactly as the library calculator does
+list($clusterResult, $cls) = coverageFixture(array(211, 122, 34), 0);
+$cov = imgcolor_SolidCoverage::calculate($clusterResult, $cls);
+approx(coverageSum($cov), 100.0, 0.001, 'without transitions solids must sum to 100.0');
+
+$libCoverage = new \ImageColorAnalyzer\CoverageCalculator\PercentageCoverageCalculator();
+$expected = array();
+foreach ($libCoverage->calculate($clusterResult) as $item) {
+    $expected[] = $item->toArray();
+}
+if ($cov !== $expected) {
+    fail('without transitions the result must equal the library calculator: ' . json_encode($cov) . ' vs ' . json_encode($expected));
+}
+
+// degenerate inputs
+list($clusterResult, $cls) = coverageFixture(array(), 0);
+if (imgcolor_SolidCoverage::calculate($clusterResult, $cls) !== array()) {
+    fail('empty cluster list must yield no colors');
+}
+
+echo "PASS: cli_separation section 4b (solid coverage)\n";
+
+// ---------------------------------------------------------------------------
 // 5) Separation orchestrator: byte parity on solid inputs, true separation
 //    on mixed inputs, transparency, determinism, performance probe
 // ---------------------------------------------------------------------------
 
+require_once __DIR__ . '/../SolidCoverage.class.php';
 require_once __DIR__ . '/../Separation.class.php';
 
 $JSON_FLAGS = JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_PRESERVE_ZERO_FRACTION;
@@ -731,11 +808,20 @@ foreach ($sep->colors as $c) {
         fail('mixed: unexpected pseudo-solid from the gradient band: ' . $c['color']);
     }
 }
+// solid percentages are shares of the whole analyzed area, on the same scale
+// as transition_coverage_percent: the two sum to exactly 100.0
 $sum = 0.0;
 foreach ($sep->colors as $c) {
     $sum += $c['coverage_percent'];
 }
-approx($sum, 100.0, 0.11, 'mixed: solid coverage still sums to ~100 over the solid area');
+approx($sum + $sep->cmyk['transition_coverage_percent'], 100.0, 0.001, 'mixed: solid + transition coverage must sum to exactly 100.0');
+// each solid keeps its own share of the image, not of the solid area: the two
+// bands are ~1/3 of the image each, and the gradient band takes the rest
+foreach ($sep->colors as $c) {
+    if ($c['coverage_percent'] > 45.0) {
+        fail('mixed: solid share inflated by a solid-only denominator: ' . $c['color'] . " at {$c['coverage_percent']}%");
+    }
+}
 
 // gradient-only image: CMYK covers nearly everything
 $im = mkImg(128, 64);


### PR DESCRIPTION
## Problem

The solid-color list on the separated analysis path came from the library's `PercentageCoverageCalculator`, which always normalizes to 100% over **the pixels handed to the clusterer**. Transition (gradient) pixels are masked out *before* clustering, so the gradient area dropped out of the denominator and the solids were inflated to fill it.

On a test image that is one third green, one third gradient, one third blue, both solids reported **~50%** — with the gradient invisible in the denominator.

## Fix

New `imgcolor_SolidCoverage` computes coverage against `analyzedCount` — the same denominator `transition_coverage_percent` already uses. Same largest-remainder rounding and tie-break rules as the library; only the denominator differs. The library class can't express this (its denominator is fixed to what it was handed), so it stays in use on the legacy un-separated path, where the two denominators coincide anyway.

The solid budget is derived as `100% − rounded transition share` from the same pixel counters, so the two blocks land on exactly 100.0 rather than 99.9/100.1 from rounding each half independently.

Same image now reads:

```
#213CC7   33.9%      (blue solid)
#21793C   33.8%      (green solid)
transitions (CMYK)  32.3%
grand total        100.0%
```

## Contract change

**Solid percentages no longer sum to 100 on their own** — they sum to `100 − transition_coverage_percent`. That's the point of the change, but it is a shift for anything reading the `colors` JSON. Documented in the v0.4 semantics note in `imgcolor/docs/integration.md`, and stated in the `analyze_image_print_colors_separated` tool description so LLM consumers read the numbers correctly.

With no transitions the two denominators coincide and output is identical to the library calculator's, so the byte-parity regression on the solid path still holds.

Also labels the demo swatch list with its scale (`Плътни цветове: 67.7% от анализираната площ`) — it had no header, which would have left the new denominator invisible in the UI.

## Testing

All six framework-free CLI suites pass, including the existing byte-parity regressions:

```
php imgcolor/tests/cli_separation.php   # + new section 4b (solid coverage)
php imgcolor/tests/cli_parity.php
# cli_setup_bucket, cli_calibration, cli_analysis_snapshot, cli_init_signature
```

New coverage in `cli_separation.php`: solid+transition sums to exactly 100.0; a solid over a mostly-gradient image reads as its true share; no-transition output is element-for-element equal to the library calculator's.

The DB-backed web tests (`imgcolor_tests_Separation` et al.) have **not** been run — they need a configured bgERP instance. None of them assert solid sums, so I expect them green, but that is an expectation, not a verified result.